### PR TITLE
Fix missing sparsezoo.utils imports

### DIFF
--- a/src/sparsezoo/__init__.py
+++ b/src/sparsezoo/__init__.py
@@ -1,8 +1,10 @@
 import os
 from types import SimpleNamespace
-from collections import defaultdict
+
 import numpy as np
-import onnx
+
+from . import utils
+from .utils.registry import RegistryMixin, _ALIAS_REGISTRY, _REGISTRY, standardize_lookup_name
 
 
 class File:
@@ -50,27 +52,9 @@ class Model:
 
 
 # utilities module-like object
-class utils:
-    @staticmethod
-    def validate_onnx(model):
-        if isinstance(model, str):
-            model = onnx.load(model)
-        onnx.checker.check_model(model)
-        return True
 
-    @staticmethod
-    def save_onnx(model, path):
-        onnx.save(model, path)
-
-    @staticmethod
-    def load_numpy_list(path_glob):
-        if isinstance(path_glob, list):
-            return [np.asarray(x) for x in path_glob]
-        return [np.zeros(1)]
-
-    @staticmethod
-    def download_file(url: str, save_path: str):
-        open(save_path, "wb").close()
+# expose utils package for compatibility
+utils = utils
 
 
 class analytics:
@@ -82,13 +66,4 @@ class analytics:
             pass
 
 
-# registry utilities
-class RegistryMixin:
-    pass
-
-_REGISTRY = defaultdict(dict)
-_ALIAS_REGISTRY = defaultdict(dict)
-
-
-def standardize_lookup_name(name: str) -> str:
-    return name.lower()
+# registry utilities are provided in sparsezoo.utils.registry

--- a/src/sparsezoo/utils/__init__.py
+++ b/src/sparsezoo/utils/__init__.py
@@ -1,0 +1,43 @@
+import numpy as np
+import onnx
+from onnx import ModelProto
+from typing import Any, Iterable
+
+__all__ = [
+    "validate_onnx",
+    "save_onnx",
+    "load_model",
+    "onnx_includes_external_data",
+    "load_numpy_list",
+    "download_file",
+    "EXTERNAL_ONNX_DATA_NAME",
+]
+
+EXTERNAL_ONNX_DATA_NAME = "model.data"
+
+def validate_onnx(model: Any) -> bool:
+    if isinstance(model, str):
+        model = onnx.load(model)
+    onnx.checker.check_model(model)
+    return True
+
+def save_onnx(model: ModelProto, path: str, **kwargs) -> None:
+    onnx.save(model, path)
+
+def load_model(model: Any, load_external_data: bool = True) -> ModelProto:
+    if isinstance(model, ModelProto):
+        return model
+    return onnx.load(model)
+
+def onnx_includes_external_data(model: ModelProto) -> bool:
+    if isinstance(model, str):
+        model = onnx.load(model)
+    return any(init.external_data for init in model.graph.initializer)
+
+def load_numpy_list(path_glob: Iterable[Any]):
+    if isinstance(path_glob, list):
+        return [np.asarray(x) for x in path_glob]
+    return [np.zeros(1)]
+
+def download_file(url: str, save_path: str) -> None:
+    open(save_path, "wb").close()

--- a/src/sparsezoo/utils/registry.py
+++ b/src/sparsezoo/utils/registry.py
@@ -1,0 +1,12 @@
+from collections import defaultdict
+
+__all__ = ["RegistryMixin", "_REGISTRY", "_ALIAS_REGISTRY", "standardize_lookup_name"]
+
+class RegistryMixin:
+    pass
+
+_REGISTRY = defaultdict(dict)
+_ALIAS_REGISTRY = defaultdict(dict)
+
+def standardize_lookup_name(name: str) -> str:
+    return name.lower()


### PR DESCRIPTION
## Summary
- add a tiny `sparsezoo.utils` package with ONNX helper stubs and registry stubs
- expose the new utils from `sparsezoo.__init__`

## Testing
- `uv run make test` *(fails: No route to host while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683b018efed0832695a74a90e685b6dd