### PR TITLE
Implement optional imports and update sparsification info

### DIFF
--- a/src/sparseml/deepsparse/base.py
+++ b/src/sparseml/deepsparse/base.py
@@ -17,15 +17,10 @@ import functools
 from typing import Optional
 
 from sparseml.base import check_version
+from sparseml.utils.imports import optional_import
 
 
-try:
-    import deepsparse
-
-    deepsparse_err = None
-except Exception as err:
-    deepsparse = object()  # TODO: populate with fake object for necessary imports
-    deepsparse_err = err
+deepsparse, deepsparse_err = optional_import("deepsparse")
 
 
 __all__ = [

--- a/src/sparseml/deepsparse/framework/info.py
+++ b/src/sparseml/deepsparse/framework/info.py
@@ -129,7 +129,7 @@ def framework_info() -> FrameworkInfo:
             "sparsified models using AVX and VNNI instruction sets"
         ),
         device="cpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=check_deepsparse_install(raise_on_error=False),
         properties={
             "cpu_architecture": arch,

--- a/src/sparseml/keras/base.py
+++ b/src/sparseml/keras/base.py
@@ -17,39 +17,21 @@ import functools
 from typing import Optional
 
 from sparseml.base import check_version
+from sparseml.utils.imports import optional_import
 
 
-try:
-    import keras
+keras, keras_err = optional_import("keras")
+is_native_keras = keras_err is None
 
+tensorflow, tensorflow_err = optional_import("tensorflow")
+if keras_err and tensorflow_err is None:
+    from tensorflow import keras as tf_keras
+
+    keras = tf_keras
     keras_err = None
-    is_native_keras = True
-except Exception as err:
-    keras = object()
-    keras_err = err
     is_native_keras = False
 
-try:
-    import tensorflow
-
-    tensorflow_err = None
-
-    if keras_err:
-        from tensorflow import keras
-
-        keras_err = None
-except Exception as err:
-    tensorflow = object()  # TODO: populate with fake object for necessary improvements
-    tensorflow_err = err
-
-
-try:
-    import keras2onnx
-
-    keras2onnx_err = None
-except Exception as err:
-    keras2onnx = object()  # TODO: populate with fake object for necessary imports
-    keras2onnx_err = err
+keras2onnx, keras2onnx_err = optional_import("keras2onnx")
 
 
 __all__ = [

--- a/src/sparseml/keras/framework/info.py
+++ b/src/sparseml/keras/framework/info.py
@@ -103,7 +103,7 @@ def framework_info() -> FrameworkInfo:
         name="cpu",
         description="Base CPU provider within Keras",
         device="cpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=check_keras_install(raise_on_error=False),
         properties={},
         warnings=[],
@@ -112,7 +112,7 @@ def framework_info() -> FrameworkInfo:
         name="cuda",
         description="Base GPU CUDA provider within Keras",
         device="gpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=(
             check_keras_install(raise_on_error=False)
             and tensorflow.test.is_gpu_available()

--- a/src/sparseml/onnx/base.py
+++ b/src/sparseml/onnx/base.py
@@ -17,24 +17,11 @@ import functools
 from typing import Optional
 
 from sparseml.base import check_version
+from sparseml.utils.imports import optional_import
 
 
-try:
-    import onnx
-
-    onnx_err = None
-except Exception as err:
-    onnx = object()  # TODO: populate with fake object for necessary imports
-    onnx_err = err
-
-try:
-    import onnxruntime
-
-    onnxruntime_err = None
-
-except Exception as error:
-    onnxruntime = object()  # TODO: populate with fake object for necessary imports
-    onnxruntime_err = error
+onnx, onnx_err = optional_import("onnx")
+onnxruntime, onnxruntime_err = optional_import("onnxruntime")
 
 __all__ = [
     "onnx",

--- a/src/sparseml/onnx/framework/info.py
+++ b/src/sparseml/onnx/framework/info.py
@@ -111,7 +111,7 @@ def framework_info() -> FrameworkInfo:
         name="cpu",
         description="Base CPU provider within ONNXRuntime",
         device="cpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=(
             check_onnx_install(raise_on_error=False)
             and check_onnxruntime_install(raise_on_error=False)
@@ -124,7 +124,7 @@ def framework_info() -> FrameworkInfo:
         name="cuda",
         description="Base GPU CUDA provider within ONNXRuntime",
         device="gpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=(
             check_onnx_install(raise_on_error=False)
             and check_onnxruntime_install(raise_on_error=False)

--- a/src/sparseml/pytorch/base.py
+++ b/src/sparseml/pytorch/base.py
@@ -16,23 +16,11 @@ import functools
 from typing import Optional
 
 from sparseml.base import check_version
+from sparseml.utils.imports import optional_import
 
 
-try:
-    import torch
-
-    torch_err = None
-except Exception as err:
-    torch = object()  # TODO: populate with fake object for necessary imports
-    torch_err = err
-
-try:
-    import torchvision
-
-    torchvision_err = None
-except Exception as err:
-    torchvision = object()  # TODO: populate with fake object for necessary imports
-    torchvision_err = err
+torch, torch_err = optional_import("torch")
+torchvision, torchvision_err = optional_import("torchvision")
 
 
 __all__ = [

--- a/src/sparseml/pytorch/framework/info.py
+++ b/src/sparseml/pytorch/framework/info.py
@@ -105,7 +105,7 @@ def framework_info() -> FrameworkInfo:
         name="cpu",
         description="Base CPU provider within PyTorch",
         device="cpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=check_torch_install(raise_on_error=False),
         properties={},
         warnings=[],
@@ -114,7 +114,7 @@ def framework_info() -> FrameworkInfo:
         name="cuda",
         description="Base GPU CUDA provider within PyTorch",
         device="gpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=(
             check_torch_install(raise_on_error=False) and torch.cuda.is_available()
         ),

--- a/src/sparseml/tensorflow_v1/base.py
+++ b/src/sparseml/tensorflow_v1/base.py
@@ -18,31 +18,21 @@ import os
 from typing import Optional
 
 from sparseml.base import check_version
+from sparseml.utils.imports import optional_import
 
 
-try:
-    import tensorflow
-
+tensorflow, tensorflow_err = optional_import("tensorflow")
+if tensorflow_err is None:
     tf_compat = (
         tensorflow
         if not hasattr(tensorflow, "compat")
         or not hasattr(getattr(tensorflow, "compat"), "v1")
         else tensorflow.compat.v1
     )
-    tensorflow_err = None
-except Exception as err:
-    tensorflow = object()  # TODO: populate with fake object for necessary imports
-    tf_compat = object()  # TODO: populate with fake object for necessary imports
-    tensorflow_err = err
+else:
+    tf_compat = tensorflow
 
-
-try:
-    import tf2onnx
-
-    tf2onnx_err = None
-except Exception as err:
-    tf2onnx = object()  # TODO: populate with fake object for necessary imports
-    tf2onnx_err = err
+tf2onnx, tf2onnx_err = optional_import("tf2onnx")
 
 
 __all__ = [

--- a/src/sparseml/tensorflow_v1/framework/info.py
+++ b/src/sparseml/tensorflow_v1/framework/info.py
@@ -103,7 +103,7 @@ def framework_info() -> FrameworkInfo:
         name="cpu",
         description="Base CPU provider within TensorFlow",
         device="cpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=check_tensorflow_install(raise_on_error=False),
         properties={},
         warnings=[],
@@ -112,7 +112,7 @@ def framework_info() -> FrameworkInfo:
         name="cuda",
         description="Base GPU CUDA provider within TensorFlow",
         device="gpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=sparsification_info(),
         available=(
             check_tensorflow_install(raise_on_error=False)
             and get_version("tensorflow_gpu", raise_on_error=False) is not None

--- a/src/sparseml/utils/__init__.py
+++ b/src/sparseml/utils/__init__.py
@@ -24,3 +24,4 @@ from .restricted_eval import *
 from .singleton import *
 from .worker import *
 from .wrapper import *
+from .imports import *

--- a/src/sparseml/utils/imports.py
+++ b/src/sparseml/utils/imports.py
@@ -1,0 +1,28 @@
+"""Utility helpers for optional imports."""
+
+from types import ModuleType
+import importlib
+
+__all__ = ["optional_import", "MissingModule"]
+
+
+class MissingModule(ModuleType):
+    """Placeholder object for optional dependencies."""
+
+    def __init__(self, name: str, err: Exception):
+        super().__init__(name)
+        self._err = err
+
+    def __getattr__(self, item):  # pragma: no cover - simple error propagation
+        raise ModuleNotFoundError(
+            f"Optional dependency '{self.__name__}' is required but missing: {self._err}"
+        )
+
+
+def optional_import(name: str):
+    """Attempt to import a module, returning a stub and error if unavailable."""
+    try:
+        module = importlib.import_module(name)
+        return module, None
+    except Exception as err:  # pragma: no cover - optional dependency stub
+        return MissingModule(name, err), err


### PR DESCRIPTION
## Summary
- add optional import helpers with stubs
- switch framework base modules to use optional_import
- return real sparsification_info for each provider

## Testing
- `make test` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683b2cc9d3208326b1f6a696c4601cd8