### PR TITLE
Improve logging for import errors

### DIFF
--- a/src/sparseml/evaluation/integrations/lm_evaluation_harness.py
+++ b/src/sparseml/evaluation/integrations/lm_evaluation_harness.py
@@ -24,6 +24,12 @@ try:
     from lm_eval.models.huggingface import HFLM
 except ImportError as import_error:
     HFLM = object
+    _LOGGER.exception(
+        "package `lm_eval` not found. Please install it via "
+        "`pip install lm-eval==0.4.1;pip uninstall transformers &&"
+        " pip install sparseml[transformers,torch]`",
+        exc_info=True,
+    )
     raise ImportError(
         "package `lm_eval` not found. Please install it via "
         "`pip install lm-eval==0.4.1;pip uninstall transformers &&"
@@ -38,6 +44,7 @@ try:
         SparseAutoModelForCausalLM,
     )
 except ImportError as import_error:
+    _LOGGER.exception("Failed to import transformers dependencies", exc_info=True)
     raise import_error
 
 __all__ = ["lm_eval_harness", "SparseMLLM"]

--- a/src/sparseml/evaluation/integrations/perplexity.py
+++ b/src/sparseml/evaluation/integrations/perplexity.py
@@ -25,6 +25,9 @@ try:
     from torch.nn import CrossEntropyLoss
     from tqdm import tqdm
 except ImportError as err:
+    _LOGGER.exception(
+        "Required packages for perplexity evaluation are missing", exc_info=True
+    )
     raise ImportError(
         "perplexity evaluation requires the following packages to be installed: "
         "datasets, numpy, torch, tqdm, transformers kindly install these packages "

--- a/src/sparseml/evaluation/registry.py
+++ b/src/sparseml/evaluation/registry.py
@@ -99,7 +99,9 @@ def collect_integrations(
             spec.loader.exec_module(module)
             _LOGGER.info(f"Auto collected {name} integration for eval")
         except ImportError as import_error:
-            _LOGGER.warning(f"Collection of {name} integration for eval failed")
+            _LOGGER.exception(
+                f"Collection of {name} integration for eval failed", exc_info=True
+            )
             raise import_error
     else:
         raise ValueError(f"No registered integrations found for the given name {name}")

--- a/src/sparseml/export/validators.py
+++ b/src/sparseml/export/validators.py
@@ -157,6 +157,9 @@ def validate_correctness(
     try:
         import onnxruntime as ort
     except ImportError as err:
+        _LOGGER.exception(
+            "onnxruntime required for correctness validation", exc_info=True
+        )
         raise ImportError(
             "The onnxruntime package is required for the correctness validation. "
             "Please install it using 'pip install sparseml[onnxruntime]'."

--- a/src/sparseml/integration_helper_functions.py
+++ b/src/sparseml/integration_helper_functions.py
@@ -15,6 +15,7 @@
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+import logging
 
 from pydantic import BaseModel, Field
 
@@ -24,6 +25,8 @@ from sparsezoo.utils.registry import RegistryMixin
 
 
 __all__ = ["IntegrationHelperFunctions", "resolve_integration"]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Integrations(Enum):
@@ -95,7 +98,7 @@ def remove_past_key_value_support_from_config(config):
 
 
 def _infer_integration_from_source_path(
-    source_path: Union[Path, str, None] = None
+    source_path: Union[Path, str, None] = None,
 ) -> Optional[str]:
     """
     Infer the integration to use from the source_path.
@@ -110,14 +113,16 @@ def _infer_integration_from_source_path(
         from sparseml.pytorch.image_classification.utils.helpers import (
             is_image_classification_model,
         )
-    except ImportError:
-        # unable to import integration, always return False
+    except ImportError as err:
+        _LOGGER.exception(
+            "Unable to import image classification helpers", exc_info=True
+        )
         is_image_classification_model = _null_is_model
 
     try:
         from sparseml.transformers.utils.helpers import is_transformer_model
-    except ImportError:
-        # unable to import integration, always return False
+    except ImportError as err:
+        _LOGGER.exception("Unable to import transformer helpers", exc_info=True)
         is_transformer_model = _null_is_model
 
     if is_image_classification_model(source_path):

--- a/src/sparseml/onnx/base.py
+++ b/src/sparseml/onnx/base.py
@@ -14,9 +14,13 @@
 
 
 import functools
+import logging
 from typing import Optional
 
 from sparseml.base import check_version
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 try:
@@ -24,7 +28,8 @@ try:
 
     onnx_err = None
 except Exception as err:
-    onnx = object()  # TODO: populate with fake object for necessary imports
+    _LOGGER.exception("Failed to import onnx, using placeholder", exc_info=True)
+    onnx = object()
     onnx_err = err
 
 try:
@@ -33,7 +38,8 @@ try:
     onnxruntime_err = None
 
 except Exception as error:
-    onnxruntime = object()  # TODO: populate with fake object for necessary imports
+    _LOGGER.exception("Failed to import onnxruntime, using placeholder", exc_info=True)
+    onnxruntime = object()
     onnxruntime_err = error
 
 __all__ = [

--- a/src/sparseml/onnx/framework/info.py
+++ b/src/sparseml/onnx/framework/info.py
@@ -111,7 +111,7 @@ def framework_info() -> FrameworkInfo:
         name="cpu",
         description="Base CPU provider within ONNXRuntime",
         device="cpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=SparsificationInfo(),
         available=(
             check_onnx_install(raise_on_error=False)
             and check_onnxruntime_install(raise_on_error=False)
@@ -120,11 +120,14 @@ def framework_info() -> FrameworkInfo:
         properties={},
         warnings=[],
     )
+    _LOGGER.info(
+        "Sparsification info for ONNXRuntime CPU provider not fully implemented"
+    )
     gpu_provider = FrameworkInferenceProviderInfo(
         name="cuda",
         description="Base GPU CUDA provider within ONNXRuntime",
         device="gpu",
-        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        supported_sparsification=SparsificationInfo(),
         available=(
             check_onnx_install(raise_on_error=False)
             and check_onnxruntime_install(raise_on_error=False)
@@ -132,6 +135,9 @@ def framework_info() -> FrameworkInfo:
         ),
         properties={},
         warnings=[],
+    )
+    _LOGGER.info(
+        "Sparsification info for ONNXRuntime CUDA provider not fully implemented"
     )
 
     return FrameworkInfo(

--- a/src/sparseml/onnx/sparsification/info.py
+++ b/src/sparseml/onnx/sparsification/info.py
@@ -36,7 +36,7 @@ def sparsification_info() -> SparsificationInfo:
     :rtype: SparsificationInfo
     """
     _LOGGER.debug("getting sparsification info for onnx")
-    info = SparsificationInfo(modifiers=[])  # TODO: fill in once available
-    _LOGGER.info("retrieved sparsification info for onnx: %s", info)
+    info = SparsificationInfo(modifiers=[])
+    _LOGGER.info("sparsification modifier list incomplete: %s", info)
 
     return info

--- a/src/sparseml/onnx/utils/model.py
+++ b/src/sparseml/onnx/utils/model.py
@@ -239,7 +239,7 @@ class OpenVINOModelRunner(ModelRunner):
 
     def __init__(
         self,
-        model: str,  # TODO: accept ONNX as input
+        model: str,
         loss: Union[
             Callable[[Dict[str, numpy.ndarray], Dict[str, numpy.ndarray]], Any], None
         ] = None,
@@ -247,6 +247,10 @@ class OpenVINOModelRunner(ModelRunner):
         batch_size: int = 0,
         shape: str = "",
     ):
+        if isinstance(model, ModelProto):
+            _LOGGER.warning(
+                "OpenVINOModelRunner received ONNX object; only file paths are supported"
+            )
         super().__init__(loss)
         self._loss = loss
 
@@ -484,9 +488,11 @@ class ORTModelRunner(ModelRunner):
         )
 
         self._session = onnxruntime.InferenceSession(
-            self._model.SerializeToString()
-            if not isinstance(self._model, str)
-            else self._model,
+            (
+                self._model.SerializeToString()
+                if not isinstance(self._model, str)
+                else self._model
+            ),
             sess_options,
             providers=providers,
         )

--- a/src/sparseml/openpifpaf/__init__.py
+++ b/src/sparseml/openpifpaf/__init__.py
@@ -12,15 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from sparseml.analytics import sparseml_analytics as _analytics
 
+
+_LOGGER = logging.getLogger(__name__)
 
 try:
     import cv2 as _cv2  # noqa: F401
 
     import openpifpaf as _openpifpaf  # noqa: F401
-except ImportError:
-    raise ImportError("Please install sparseml[openpifpaf] to use this pathway")
+except ImportError as err:
+    _LOGGER.exception(
+        "Please install sparseml[openpifpaf] to use this pathway", exc_info=True
+    )
+    raise ImportError(
+        "Please install sparseml[openpifpaf] to use this pathway"
+    ) from err
 
 
 _analytics.send_event("python__openpifpaf__init")

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -18,6 +18,9 @@ Functionality for working with and sparsifying Models in the PyTorch framework
 
 import os
 import warnings
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 from packaging import version
 
@@ -53,7 +56,9 @@ try:
                 "sparseml quantized onnx export does not work "
                 "with torch==1.10.* or 1.11.*"
             )
-except ImportError:
+
+except ImportError as err:
+    _LOGGER.exception("PyTorch not available", exc_info=True)
     pass
 
 # flake8: noqa

--- a/src/sparseml/pytorch/nn/activations.py
+++ b/src/sparseml/pytorch/nn/activations.py
@@ -21,13 +21,17 @@ from typing import Union
 import torch.nn.functional as TF
 from torch import Tensor, clamp
 from torch.nn import LeakyReLU, Module, PReLU
+import logging
 from torch.nn import ReLU as TReLU
 from torch.nn import ReLU6 as TReLU6
 
 
+_LOGGER = logging.getLogger(__name__)
+
 try:
     from torch.nn import SiLU
-except ImportError:
+except ImportError as err:
+    _LOGGER.exception("SiLU activation not available", exc_info=True)
     SiLU = None
 
 

--- a/src/sparseml/transformers/base.py
+++ b/src/sparseml/transformers/base.py
@@ -22,8 +22,8 @@ def check_transformers_install():
     try:
         import transformers  # noqa F401
     except ImportError as transformers_err:
-        _LOGGER.warning(
-            "transformers dependency is not installed. "
-            "To install, run `pip sparseml[transformers]`"
+        _LOGGER.exception(
+            "transformers dependency is not installed. To install, run `pip sparseml[transformers]`",
+            exc_info=True,
         )
         raise transformers_err

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -279,7 +279,8 @@ class StageRunner:
                 self.trainer.accelerator.wait_for_everyone()
                 continue
 
-            # setup checkpoint dir, TODO: this should be optional
+            # setup checkpoint dir
+            _LOGGER.info("Creating stage checkpoint directory; make optional in future")
             self._output_dir = os.path.join(
                 self.parent_output_dir, "stage_" + stage_name
             )

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -141,7 +141,7 @@ class SessionManagerMixIn:
         with summon_full_params_context(self.model, offload_to_cpu=True):
             sparseml.initialize(
                 model=self.model,
-                teacher_model=self.teacher,  # TODO: what about for self/disable?
+                teacher_model=self.teacher,
                 recipe=self.recipe,
                 recipe_stage=stage,
                 recipe_args=self.recipe_args,
@@ -152,6 +152,10 @@ class SessionManagerMixIn:
                 fsdp_active=self.is_fsdp_enabled,
                 metadata=self.metadata,
             )
+        if self.teacher:
+            _LOGGER.debug("Teacher model provided during initialization")
+        else:
+            _LOGGER.debug("No teacher model provided during initialization")
         self.accelerator.wait_for_everyone()
         model = get_session_model()
         self.model_wrapped = self.model = model
@@ -250,7 +254,7 @@ class SessionManagerMixIn:
         :param optimizer: pre-initialized optimizer
         """
 
-        # TODO: we don't currently have a LR scheduler in the new modifier framework
+        _LOGGER.info("LR scheduler not implemented for new modifier framework")
         self._check_super_defined("create_scheduler")
         return super().create_scheduler(num_training_steps, optimizer)
 
@@ -287,7 +291,7 @@ class SessionManagerMixIn:
         """
         self._check_super_defined("compute_loss")
 
-        # TODO: do we need these model signature columns?
+        _LOGGER.debug("Filtering inputs to model signature columns")
         inputs = {k: inputs[k] for k in inputs if k in self._signature_columns}
         loss = super().compute_loss(model, inputs, return_outputs=return_outputs)
 

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -298,7 +298,7 @@ def main(
     model_path = None
     model = model_args.model
     # Load tokenizer
-    # distill TODO: support for different tokenizer for teacher?
+    _LOGGER.debug("Teacher tokenizer support not yet implemented")
     tokenizer = model_args.tokenizer
 
     if isinstance(model, str) or isinstance(model, PosixPath):

--- a/src/sparseml/transformers/utils/initializers.py
+++ b/src/sparseml/transformers/utils/initializers.py
@@ -156,7 +156,7 @@ def initialize_trainer(
     :param validation_dataset: the validation dataset to use for the trainer
     :return: the initialized trainer
     """
-    # TODO: add here support for v2 trainer
+    _LOGGER.debug("Trainer initialization for v2 API not yet implemented")
     # also add initialize_dataset function that will merge v1 and v2 functions
 
     training_args = TrainingArguments(

--- a/src/sparseml/utils/fsdp/context.py
+++ b/src/sparseml/utils/fsdp/context.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
 try:
     from torch.distributed.fsdp import FullyShardedDataParallel
     from torch.distributed.fsdp._common_utils import TrainingState
 
     from accelerate import Accelerator
-except ImportError:
+except ImportError as err:
+    LOGGER.exception("FSDP utilities not available", exc_info=True)
     FullyShardedDataParallel = None
     Accelerator = None
 

--- a/src/sparseml/utils/fsdp/helpers.py
+++ b/src/sparseml/utils/fsdp/helpers.py
@@ -24,7 +24,8 @@ try:
         FullyShardedDataParallel,
         StateDictType,
     )
-except ImportError:
+except ImportError as err:
+    _LOGGER.exception("torch.distributed.fsdp not available", exc_info=True)
     FullyShardedDataParallel = None
 
 import torch

--- a/src/sparseml/yolov5/__init__.py
+++ b/src/sparseml/yolov5/__init__.py
@@ -27,8 +27,11 @@ try:
     import torchvision as _torchvision
 
     import yolov5 as _yolov5
-except ImportError:
-    raise ImportError("Please install sparseml[yolov5] to use this pathway")
+except ImportError as err:
+    _LOGGER.exception(
+        "Please install sparseml[yolov5] to use this pathway", exc_info=True
+    )
+    raise ImportError("Please install sparseml[yolov5] to use this pathway") from err
 
 _analytics.send_event("python__yolov5__init")
 

--- a/src/sparseml/yolov8/__init__.py
+++ b/src/sparseml/yolov8/__init__.py
@@ -12,14 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import ultralytics
 from sparseml.analytics import sparseml_analytics as _analytics
+
+_LOGGER = logging.getLogger(__name__)
 
 
 try:
     import ultralytics as _ultralytics  # noqa: F401
-except ImportError:
-    raise ImportError("Please install sparseml[yolov8] to use this pathway")
+except ImportError as err:
+    _LOGGER.exception(
+        "Please install sparseml[yolov8] to use this pathway", exc_info=True
+    )
+    raise ImportError("Please install sparseml[yolov8] to use this pathway") from err
 
 
 _analytics.send_event("python__yolov8__init")

--- a/tests/sparseml/test_import_error_logging.py
+++ b/tests/sparseml/test_import_error_logging.py
@@ -1,0 +1,31 @@
+import importlib
+import builtins
+import logging
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def ensure_sparseml_path():
+    sys.path.insert(0, "src")
+    yield
+    sys.path.remove("src")
+
+
+def test_onnx_base_logs_on_import_error(monkeypatch, caplog):
+    import sparseml.onnx.base
+
+    # reload module with failing imports
+    original_import = builtins.__import__
+
+    def mocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in ("onnx", "onnxruntime"):
+            raise ImportError("mocked failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", mocked_import)
+    caplog.set_level(logging.ERROR)
+    importlib.reload(sparseml.onnx.base)
+    assert "Failed to import onnx" in caplog.text
+    assert "Failed to import onnxruntime" in caplog.text


### PR DESCRIPTION
## Summary
- log when ONNX and ONNXRuntime imports fail
- log missing integration helper imports
- capture import failures in evaluation integrations
- replace TODO comments with debug/info logs
- add test for logging on import failure

## Testing
- `pytest -q tests/sparseml/test_import_error_logging.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683b2ce7f9488326a2fc2ef96b4d64ed