### PR TITLE
Remove neuralmagic links

### DIFF
--- a/.github/workflows/util.yml
+++ b/.github/workflows/util.yml
@@ -104,7 +104,7 @@ jobs:
              echo "========== Build info ==========="
              echo "name: ${name}"
              echo "build: $GITHUB_OUTPUT"
-             echo "echo \"GHA job $GITHUB_OUTPUT: https://github.com/neuralmagic/${{ github.event.repository.name }}/actions/runs/${{ inputs.run_id }}\"; exit ${exitCode}" > result.sh
+             echo "echo \"GHA job $GITHUB_OUTPUT: https://github.com/100latent/${{ github.event.repository.name }}/actions/runs/${{ inputs.run_id }}\"; exit ${exitCode}" > result.sh
              echo "========== Report to testmo ==========="
              echo "testmo automation:run:submit \\"
              echo "  --instance ${TESTMO_URL} \\"

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -26,7 +26,7 @@ Here are some details to get started.
 **Development Installation**
 
 ```bash
-git clone https://github.com/neuralmagic/sparseml.git
+git clone https://github.com/100latent/sparseml.git
 cd sparseml
 python3 -m pip install -e "./[dev]"
 ```
@@ -71,7 +71,7 @@ File any error found before changes as an Issue and fix any errors found after m
 
 ## GitHub Workflow
 
-1. Fork the `neuralmagic/sparseml` repository into your GitHub account: https://github.com/neuralmagic/sparseml/fork.
+1. Fork the `neuralmagic/sparseml` repository into your GitHub account: https://github.com/100latent/sparseml/fork.
 
 2. Clone your fork of the GitHub repository, replacing `<username>` with your GitHub username.
 
@@ -90,7 +90,7 @@ File any error found before changes as an Issue and fix any errors found after m
 3. Add a remote to keep up with upstream changes.
 
    ```bash
-   git remote add upstream https://github.com/neuralmagic/sparseml.git
+   git remote add upstream https://github.com/100latent/sparseml.git
    ```
 
    If you already have a copy, fetch upstream changes.

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 SparseML
 Copyright 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 
-This product includes software developed at Neuralmagic, Inc. (https://www.neuralmagic.com).
+This product includes software developed at Neuralmagic, Inc.
 
 Source code in this repository is variously licensed under the Apache License
 Version 2.0, an Apache-compatible license.
@@ -19,7 +19,6 @@ NOTICES
 ========================================================================
 
 All implementations in this repository are subject to Neural Magic's Legal Policies
-https://www.neuralmagic.com/legal
 
 Package dependencies are defined in the Python setup.py file in this repository's top-level directory and have their own Apache-compatible licenses and terms.
 
@@ -33,7 +32,7 @@ PyTorch Image Models (timm) License https://github.com/rwightman/pytorch-image-m
 
 TensorFlow License https://github.com/tensorflow/tensorflow/blob/master/LICENSE
 
-Ultralytics YOLOv* License https://github.com/neuralmagic/sparseml/blob/master/LICENSE-ULTRALYTICS
+Ultralytics YOLOv* License https://github.com/100latent/sparseml/blob/master/LICENSE-ULTRALYTICS
 
 YOLACT License https://github.com/dbolya/yolact/blob/master/LICENSE
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<h1 style="display: flex; align-items: center;" >
-     <img width="100" height="100" alt="tool icon" src="https://neuralmagic.com/wp-content/uploads/2024/03/icon_SparseML-002.svg" />
-      <span>&nbsp;&nbsp;SparseML</span>
-  </h1>
+<h1>SparseML</h1>
 
 <h3>Libraries for applying sparsification recipes to neural networks with a few lines of code, enabling faster and smaller models</h3>
 
 ## Overview
 
-SparseML is an open-source model optimization toolkit that enables you to create inference-optimized sparse models using pruning, quantization, and distillation algorithms. Models optimized with SparseML can then be exported to the ONNX and deployed with [DeepSparse](https://github.com/neuralmagic/deepsparse/) for GPU-class performance on CPU hardware.
+SparseML is an open-source model optimization toolkit that enables you to create inference-optimized sparse models using pruning, quantization, and distillation algorithms. Models optimized with SparseML can then be exported to the ONNX and deployed with DeepSparse for GPU-class performance on CPU hardware.
 
 <p align="center">
    <img alt="SparseML Flow" src="docs/images/sparseml-workflow.png" width="60%" />
@@ -35,36 +32,31 @@ Neural Magic is excited to preview one-shot LLM compression workflows using the 
 
 To prune and quantize a TinyLlama Chat model it is just a few steps to install dependencies, download a recipe, and apply it to the model:
 ```
-git clone https://github.com/neuralmagic/sparseml
+git clone https://github.com/100latent/sparseml
 pip install -e "sparseml[transformers]"
 wget https://huggingface.co/neuralmagic/TinyLlama-1.1B-Chat-v0.4-pruned50-quant-ds/raw/main/recipe.yaml
 sparseml.transformers.text_generation.oneshot --model_name TinyLlama/TinyLlama-1.1B-Chat-v1.0 --dataset_name open_platypus --recipe recipe.yaml --output_dir ./obcq_deployment --precision float16
 ```
 
-The README at [`src/sparseml/transformers/sparsification/obcq`](https://github.com/neuralmagic/sparseml/tree/main/src/sparseml/transformers/sparsification/obcq) has a detailed walkthrough.
+The README at [`src/sparseml/transformers/sparsification/obcq`](https://github.com/100latent/sparseml/tree/main/src/sparseml/transformers/sparsification/obcq) has a detailed walkthrough.
 
 ## Workflows
 
 SparseML enables you to create a sparse model trained on your dataset in two ways:
-- **Sparse Transfer Learning** enables you to fine-tune a pre-sparsified model from [SparseZoo](https://sparsezoo.neuralmagic.com/) (an open-source repository of sparse models such as BERT, YOLOv5, and ResNet-50) onto your dataset, while maintaining sparsity. This pathway works just like typical fine-tuning you are used to in training CV and NLP models, and is strongly preferred for if your model architecture is available in SparseZoo.
+- **Sparse Transfer Learning** enables you to fine-tune a pre-sparsified model from SparseZoo (an open-source repository of sparse models such as BERT, YOLOv5, and ResNet-50) onto your dataset, while maintaining sparsity. This pathway works just like typical fine-tuning you are used to in training CV and NLP models, and is strongly preferred for if your model architecture is available in SparseZoo.
 
 - **Sparsification from Scratch** enables you to apply state-of-the-art pruning (like gradual magnitude pruning or OBS pruning) and quantization (like quantization aware training) algorithms to arbitrary PyTorch and Hugging Face models. This pathway requires more experimentation, but allows you to create a sparse version of any model. 
 
 ## Integrations
 
 <p>
-    <a href="integrations/torchvision">
-        <img src="https://docs.neuralmagic.com/docs/source/highlights/sparseml/pytorch-torchvision.png" width="136px" />
-    </a>
-    <a href="integrations/ultralytics-yolov5">
-        <img src="https://docs.neuralmagic.com/docs/source/highlights/sparseml/ultralytics-yolov5.png" width="136px" />
-    </a>
-    <a href="integrations/ultralytics-yolov8">
-        <img src="docs/images/ultralytics-yolov8.png" width="136px" />
-    </a>
-    <a href="integrations/huggingface-transformers">
-        <img src="https://docs.neuralmagic.com/docs/source/highlights/sparseml/huggingface-transformers.png" width="136px" />
-    </a>
+    <a href="integrations/torchvision">Torchvision</a>
+    |
+    <a href="integrations/ultralytics-yolov5">YOLOv5</a>
+    |
+    <a href="integrations/ultralytics-yolov8">YOLOv8</a>
+    |
+    <a href="integrations/huggingface-transformers">Hugging Face Transformers</a>
 </p>
 
 ## Tutorials
@@ -106,7 +98,7 @@ Install with pip using:
 pip install sparseml
 ```
 
-More information on installation such as optional dependencies and requirements can be found [here](https://docs.neuralmagic.com/get-started/install/sparseml).
+More information on installation such as optional dependencies and requirements can be found in the documentation.
 
 ## Quick Tour
 
@@ -164,15 +156,15 @@ sparseml.yolov5.train \
 
 More information on the codebase and contained processes can be found in the SparseML docs:
 - [Examples and Tutorials](integrations)
-- [Sparsification Code](https://docs.neuralmagic.com/get-started/sparsify-a-model)
-- [Sparsification Recipes](https://docs.neuralmagic.com/user-guides/recipes)
-- [Exporting to ONNX](https://docs.neuralmagic.com/user-guides/onnx-export)
+- [Sparsification Code](integrations)
+- [Sparsification Recipes](integrations)
+- [Exporting to ONNX](integrations)
 
 ## Resources
 
 ### Learning More
 
-- Documentation: [SparseML,](https://docs.neuralmagic.com/sparseml/) [DeepSparse](https://docs.neuralmagic.com/deepsparse/)
+- Documentation: SparseML and DeepSparse
 
 ### Release History
 
@@ -181,11 +173,11 @@ Official builds are hosted on PyPI
 - stable: [sparseml](https://pypi.org/project/sparseml/)
 - nightly (dev): [sparseml-nightly](https://pypi.org/project/sparseml-nightly/)
 
-Additionally, more information can be found via [GitHub Releases.](https://github.com/neuralmagic/sparseml/releases)
+Additionally, more information can be found via [GitHub Releases.](https://github.com/100latent/sparseml/releases)
 
 ### License
 
-The project is licensed under the [Apache License Version 2.0.](https://github.com/neuralmagic/sparseml/blob/main/LICENSE)
+The project is licensed under the [Apache License Version 2.0.](https://github.com/100latent/sparseml/blob/main/LICENSE)
 
 ## Cite
 Find this project useful in your research or other communications? Please consider citing:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN \
     echo Will install from pypi based on mode and version ; \
   else  \
     echo cloning from "${BRANCH}" &&  \
-    git clone https://github.com/neuralmagic/sparseml.git --depth 1 -b "${BRANCH}" ; \
+    git clone https://github.com/100latent/sparseml.git --depth 1 -b "${BRANCH}" ; \
   fi;
 
 
@@ -131,7 +131,7 @@ RUN \
       $VENV/bin/pip install -e  "./sparseml[dev]"; \
     else \
       echo Installing from main  with editable mode && \
-      git clone https://github.com/neuralmagic/sparseml.git --depth 1 -b main && \
+      git clone https://github.com/100latent/sparseml.git --depth 1 -b main && \
       $VENV/bin/pip install -e "./sparseml[dev]"; \
     fi;
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,18 +8,18 @@ image (with CUDA support). The image comes with a pre-installed `sparseml`, as w
 This `Dockerfile` is tested on the Ubuntu 20.04.2 LTS with CUDA Version: 11.4.
 
 ## Pull
-You can access the already built image detailed at https://github.com/orgs/neuralmagic/packages/container/package/sparseml:
+You can access the already built image detailed at https://github.com/orgs/100latent/packages/container/package/sparseml:
 
 ```bash
-docker pull ghcr.io/neuralmagic/sparseml:1.4.4-cu111
-docker tag ghcr.io/neuralmagic/sparseml:1.4.4-cu111 sparseml_docker
+docker pull ghcr.io/100latent/sparseml:1.4.4-cu111
+docker tag ghcr.io/100latent/sparseml:1.4.4-cu111 sparseml_docker
 ```
 
 ## Extend
 If you would like to customize the docker image, you can use the pre-built images as a base in your own `Dockerfile`:
 
 ```Dockerfile
-from ghcr.io/neuralmagic/sparseml:1.4.4-cu111
+from ghcr.io/100latent/sparseml:1.4.4-cu111
 
 ...
 ```

--- a/docker/containers/docker_dev/Dockerfile
+++ b/docker/containers/docker_dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG SOURCE=ghcr.io/neuralmagic/cuda-python3.10
+ARG SOURCE=ghcr.io/100latent/cuda-python3.10
 
 ARG TORCH_VERSION=2.1.2
 ARG TORCHVISION_VERSION=0.16.2
@@ -17,7 +17,7 @@ ARG TORCH_VERSION
 ARG TORCHVISION_VERSION
 
 RUN python3.10 -m pip install torch==${TORCH_VERSION}+cu${CUDA} torchvision==${TORCHVISION_VERSION}+cu${CUDA} -f https://download.pytorch.org/whl/torch_stable.html \
-    && git clone https://github.com/neuralmagic/sparseml.git --depth 1 --single-branch -b ${BRANCH} \
+    && git clone https://github.com/100latent/sparseml.git --depth 1 --single-branch -b ${BRANCH} \
     && python3.10 -m pip install -e "./sparseml[dev]"
 
 HEALTHCHECK CMD python3.10 -c 'import sparseml'

--- a/docker/containers/docker_nightly/Dockerfile
+++ b/docker/containers/docker_nightly/Dockerfile
@@ -1,4 +1,4 @@
-ARG SOURCE=ghcr.io/neuralmagic/cuda-python3.10
+ARG SOURCE=ghcr.io/100latent/cuda-python3.10
 
 ARG TORCH_VERSION=2.1.2
 ARG TORCHVISION_VERSION=0.16.2

--- a/docker/containers/docker_release/Dockerfile
+++ b/docker/containers/docker_release/Dockerfile
@@ -1,4 +1,4 @@
-ARG SOURCE=ghcr.io/neuralmagic/cuda-python3.10
+ARG SOURCE=ghcr.io/100latent/cuda-python3.10
 
 ARG TORCH_VERSION=2.1.2
 ARG TORCHVISION_VERSION=0.16.2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@
     :maxdepth: 3
     :caption: Connect Online
 
-    Bugs, Feature Requests <https://github.com/neuralmagic/sparseml/issues>
+    Bugs, Feature Requests <https://github.com/100latent/sparseml/issues>
     Deep Sparse Community Slack <https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ>
-    Neural Magic GitHub <https://github.com/neuralmagic>
-    Neural Magic Docs <https://docs.neuralmagic.com>
+    Neural Magic GitHub <https://github.com/100latent>
+    Neural Magic Docs

--- a/docs/source/onnx_export.md
+++ b/docs/source/onnx_export.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # ONNX Export
 
-[ONNX](https://onnx.ai/) is a generic representation for neural network graphs that most ML frameworks can be converted to. Some inference engines such as [DeepSparse](https://github.com/neuralmagic/deepsparse) natively take in ONNX for deployment pipelines, so convenience functions for conversion and export are provided for the supported frameworks.
+[ONNX](https://onnx.ai/) is a generic representation for neural network graphs that most ML frameworks can be converted to. Some inference engines such as [DeepSparse](https://github.com/100latent/deepsparse) natively take in ONNX for deployment pipelines, so convenience functions for conversion and export are provided for the supported frameworks.
 
 ## Exporting PyTorch to ONNX
 

--- a/docs/source/recipes.md
+++ b/docs/source/recipes.md
@@ -27,7 +27,7 @@ and apply the modifications to the model and training pipeline.
 
 In a recipe, modifiers must be written in a list that includes "modifiers" in its name.
 
-The easiest ways to get or create recipes are by either using the pre-configured recipes in [SparseZoo](https://github.com/neuralmagic/sparsezoo) or using [Sparsify's](https://github.com/neuralmagic/sparsify) automatic creation.
+The easiest ways to get or create recipes are by either using the pre-configured recipes in [SparseZoo](https://github.com/100latent/sparsezoo) or using [Sparsify's](https://github.com/100latent/sparsify) automatic creation.
 
 However, power users may be inclined to create their own recipes by hand to enable more 
 fine-grained control or to add in custom modifiers.

--- a/docs/user-guide/sparseml-docker.md
+++ b/docs/user-guide/sparseml-docker.md
@@ -125,7 +125,7 @@ sparseml.image_classification.train \
     --dataset-path ./imagenette2-320 \
     --batch-size 32
  ```
- The [`recipe`](https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenet%2Fpruned95_quant-none) 
+ The `recipe` 
  instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 
 ## Object Detection
@@ -136,7 +136,7 @@ Start the SparseML container with all the available GPUs:
 ```bash 
 docker container run --gpus all -it sparseml_docker
 ```
-The CLI command below trains a YOLOv5 model on the VOC dataset with a [`recipe`](https://sparsezoo.neuralmagic.com/models/cv%2Fdetection%2Fyolov5-s%2Fpytorch%2Fultralytics%2Fcoco%2Fpruned75_quant-none) 
+The CLI command below trains a YOLOv5 model on the VOC dataset with a `recipe` 
 that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 ```bash
 sparseml.yolov5.train \

--- a/integrations/huggingface-transformers/README.md
+++ b/integrations/huggingface-transformers/README.md
@@ -64,7 +64,7 @@ pip install sparseml[transformers]
 
 SparseZoo is an open-source repository of pre-sparsified models, including BERT-base, BERT-large, RoBERTa-base, RoBERTa-large, and DistillBERT. With SparseML, you can fine-tune these pre-sparsified checkpoints onto custom datasets (while maintaining sparsity) via sparse transfer learning. This makes training inference-optimized sparse models almost identical to your typical training workflows!
 
-[Check out the available models](https://sparsezoo.neuralmagic.com/?repos=huggingface)
+Check out the available models
 
 ### **Recipes**
 
@@ -138,7 +138,7 @@ Currently supported tasks include:
 
 Sparse Transfer is very similiar to the typical transfer learing process used to train NLP models, where we fine-tune a checkpoint pretrained on a large upstream dataset using masked language modeling onto a smaller downstream dataset. With Sparse Transfer Learning, however, we simply start the fine-tuning process from a pre-sparsified checkpoint and maintain sparsity while the training process occurs.
 
-Here, we will fine-tune a [90% pruned version of BERT](https://sparsezoo.neuralmagic.com/models/obert-base-wikipedia_bookcorpus-pruned90?comparison=obert-base-wikipedia_bookcorpus-base) from the SparseZoo onto SST2.
+Here, we will fine-tune a 90% pruned version of BERT from the SparseZoo onto SST2.
 
 ### **Kick off Training**
 
@@ -146,7 +146,7 @@ We will use SparseML's `sparseml.transformers.text_classification` training scri
 
 To run sparse transfer learning, we first need to create/select a sparsification recipe. For sparse transfer, we need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model. 
 
-For the SST2 dataset, there is a [transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/obert-base-sst2_wikipedia_bookcorpus-pruned90_quantized?comparison=obert-base-sst2_wikipedia_bookcorpus-base&tab=0), identified by the following SparseZoo stub:
+For the SST2 dataset, there is a transfer learning recipe available in SparseZoo, identified by the following SparseZoo stub:
 ```
 zoo:nlp/sentiment_analysis/obert-base/pytorch/huggingface/sst2/pruned90_quant-none
 ```

--- a/integrations/huggingface-transformers/tutorials/question-answering/question-answering-cli.md
+++ b/integrations/huggingface-transformers/tutorials/question-answering/question-answering-cli.md
@@ -26,8 +26,8 @@ Sparse Transfer Learning is very similiar to the typical transfer learning proce
 
 SparseZoo, Neural Magic's open source repository of pre-sparsified models, contains a 90% pruned version of BERT, which has been sparsified on the upstream Wikipedia and BookCorpus datasets with the masked language modeling objective.  We will use this model as the starting point for the transfer learning process.
 
-- [Check out 90% pruned BERT model card](https://sparsezoo.neuralmagic.com/models/nlp%2Fmasked_language_modeling%2Fobert-base%2Fpytorch%2Fhuggingface%2Fwikipedia_bookcorpus%2Fpruned90-none)
-- [Check out the full list of pre-sparsified NLP models](https://sparsezoo.neuralmagic.com/?domain=nlp&sub_domain=masked_language_modeling&page=1)
+- Check out 90% pruned BERT model card
+- Check out the full list of pre-sparsified NLP models
 
 ### Table of Contents
 
@@ -63,7 +63,7 @@ To launch a Sparse Transfer Learning run, we first need to create a Sparse Trans
 
 Recipes are YAML files that specify sparsity related algorithms and hyper-parameters. SparseML parses the recipes and updates the training loops to apply the specified sparsification algorithms to the model.
 
-In the case of SQUAD, there is a [premade transfer recipe in the SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fquestion_answering%2Fbert-large%2Fpytorch%2Fhuggingface%2Fsquad%2Fpruned90_quant-none):
+In the case of SQUAD, there is a premade transfer recipe in the SparseZoo:
 
 
 ```yaml
@@ -320,7 +320,7 @@ sparseml.transformers.train.question_answering \
 ```
 
 Note that we used the dense version of BERT (the stub ends in `base-none`) as the starting point for the training 
-and passed a recipe from [SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fquestion_answering%2Fbert-large%2Fpytorch%2Fhuggingface%2Fsquad%2Fbase-none) which was used to train the 
+and passed a recipe from SparseZoo which was used to train the 
 dense teacher for the SQuAD task. Since the SQuAD task is similiar to the Squadshifts Amazon task, these hyperparameters are a solid starting point. This recipe contains no sparsity related modifiers and only controls the learning rate and number of epochs. As such, no pruning is applied, resulting in a dense model.
 
 Here's what the recipe looks like:

--- a/integrations/huggingface-transformers/tutorials/sentiment-analysis/sentiment-analysis-cli.md
+++ b/integrations/huggingface-transformers/tutorials/sentiment-analysis/sentiment-analysis-cli.md
@@ -26,8 +26,8 @@ Sparse Transfer Learning is very similiar to the typical transfer learning proce
 
 SparseZoo, Neural Magic's open source repository of pre-sparsified models, contains a 90% pruned version of BERT, which has been sparsified on the upstream Wikipedia and BookCorpus datasets with the masked language modeling objective.  We will use this model as the starting point for the transfer learning process.
 
-- [Check out 90% pruned BERT model card](https://sparsezoo.neuralmagic.com/models/nlp%2Fmasked_language_modeling%2Fobert-base%2Fpytorch%2Fhuggingface%2Fwikipedia_bookcorpus%2Fpruned90-none)
-- [Check out the full list of pre-sparsified NLP models](https://sparsezoo.neuralmagic.com/?domain=nlp&sub_domain=masked_language_modeling&page=1)
+- Check out 90% pruned BERT model card
+- Check out the full list of pre-sparsified NLP models
 
 ### Table of Contents
 
@@ -61,7 +61,7 @@ To launch a Sparse Transfer Learning run, we first need to create a Sparse Trans
 
 Recipes are YAML files that specify sparsity related algorithms and hyper-parameters. SparseML parses the recipes and updates the training loops to apply the specified sparsification algorithms to the model.
 
-In the case of SST2, there is a [premade recipe in the SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fsentiment_analysis%2Fobert-base%2Fpytorch%2Fhuggingface%2Fsst2%2Fpruned90_quant-none):
+In the case of SST2, there is a premade recipe in the SparseZoo:
 
 ```yaml
 version: 1.1.0
@@ -304,7 +304,7 @@ sparseml.transformers.train.text_classification \
 The model converges to ~86.9% accuracy without any hyperparameter search.
 
 Note that used the dense version of BERT (the stub ends in `base-none`) as the starting point for the training 
-and passed a recipe from [SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fsentiment_analysis%2Fbert-base%2Fpytorch%2Fhuggingface%2Fsst2%2Fbase-none) which was used to train the 
+and passed a recipe from SparseZoo which was used to train the 
 dense teacher for the SST2 task. Since the SST2 task is similiar to the Rotten Tomatoes task, these parameters are a solid
 place to start. This recipe contains no sparsity related modifiers and only controls the learning rate and number of epochs. As such, the script
 will run typical fine-tuning, resulting in a dense model.

--- a/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert-python.md
+++ b/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert-python.md
@@ -24,7 +24,7 @@ Sparse Transfer Learning is quite similiar to typical NLP transfer learning, whe
 
 SparseZoo contains pre-sparsified checkpoints of common NLP models like BERT and RoBERTa. These models can be used as the starting checkpoint for the sparse transfer learning workflow.
 
-[Check out the full list of pre-sparsified models](https://sparsezoo.neuralmagic.com/?domain=nlp&sub_domain=masked_language_modeling&page=1)
+Check out the full list of pre-sparsified models
 
 ## **Installation**
 
@@ -41,7 +41,7 @@ dataset, with each sentence labeled with a 0 or 1 representing negative or posit
 
 ### **Step 1: Download Pre-Sparsified Checkpoint**
 
-We will fine-tune a [90% pruned BERT-base](https://sparsezoo.neuralmagic.com/models/nlp%2Fmasked_language_modeling%2Fobert-base%2Fpytorch%2Fhuggingface%2Fwikipedia_bookcorpus%2Fpruned90-none), identified by the following stub:
+We will fine-tune a 90% pruned BERT-base, identified by the following stub:
 ```bash
 zoo:nlp/masked_language_modeling/obert-base/pytorch/huggingface/wikipedia_bookcorpus/pruned90-none
 ```
@@ -56,7 +56,7 @@ model_path = zoo_model.training.path
 
 Additionally, SparseML allows you to apply model distillation from a dense teacher model during the fine-tuning process. This is an optional step, but it can help increase accuracy.
 
-For SST2, there is a [dense BERT-base](https://sparsezoo.neuralmagic.com/models/nlp%2Fsentiment_analysis%2Fobert-base%2Fpytorch%2Fhuggingface%2Fsst2%2Fbase-none) trained on SST2, identified by the following stub:
+For SST2, there is a dense BERT-base trained on SST2, identified by the following stub:
 
 ```bash
 zoo:nlp/sentiment_analysis/obert-base/pytorch/huggingface/sst2/base-none
@@ -135,7 +135,7 @@ tokenized_dataset = dataset.map(preprocess_fn, batched=True)
 
 To run sparse transfer learning, we first need to create/select a sparsification recipe. For sparse transfer, we need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 
-For the SST2 dataset, there is a [transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fsentiment_analysis%2Fobert-base%2Fpytorch%2Fhuggingface%2Fsst2%2Fpruned90_quant-none), identified by the following stub:
+For the SST2 dataset, there is a transfer learning recipe available in SparseZoo, identified by the following stub:
 ```
 zoo:nlp/sentiment_analysis/obert-base/pytorch/huggingface/sst2/pruned90_quant-none
 ```

--- a/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert.md
+++ b/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert.md
@@ -24,7 +24,7 @@ Sparse Transfer Learning is quite similiar to typical NLP transfer learning, whe
 
 SparseZoo contains pre-sparsified checkpoints of common NLP models like BERT and RoBERTa. These models can be used as the starting checkpoint for the sparse transfer learning workflow.
 
-[Check out the full list of pre-sparsified models](https://sparsezoo.neuralmagic.com/?domain=nlp&sub_domain=masked_language_modeling&page=1)
+Check out the full list of pre-sparsified models
 
 ## **Installation**
 
@@ -43,7 +43,7 @@ dataset, with each sentence labeled with a 0 or 1 representing negative or posit
 
 ### **Selecting a Pre-Sparsified Model**
 
-We will fine-tune a [90% pruned BERT-base](https://sparsezoo.neuralmagic.com/models/nlp%2Fmasked_language_modeling%2Fobert-base%2Fpytorch%2Fhuggingface%2Fwikipedia_bookcorpus%2Fpruned90-none), identified by the following stub:
+We will fine-tune a 90% pruned BERT-base, identified by the following stub:
 ```bash
 zoo:nlp/masked_language_modeling/obert-base/pytorch/huggingface/wikipedia_bookcorpus/pruned90-none
 ```
@@ -54,7 +54,7 @@ We will use SparseML's `sparseml.transformers.text_classification` training scri
 
 To run sparse transfer learning, we first need to create/select a sparsification recipe. For sparse transfer, we need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs. 
 
-For the SST2 dataset, there is a [transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fsentiment_analysis%2Fobert-base%2Fpytorch%2Fhuggingface%2Fsst2%2Fpruned90_quant-none), identified by the following stub:
+For the SST2 dataset, there is a transfer learning recipe available in SparseZoo, identified by the following stub:
 ```
 zoo:nlp/sentiment_analysis/obert-base/pytorch/huggingface/sst2/pruned90_quant-none
 ```

--- a/integrations/huggingface-transformers/tutorials/text-classification/text-classification-cli.md
+++ b/integrations/huggingface-transformers/tutorials/text-classification/text-classification-cli.md
@@ -26,8 +26,8 @@ Sparse Transfer Learning is very similiar to the typical transfer learning proce
 
 SparseZoo, Neural Magic's open source repository of pre-sparsified models, contains a 90% pruned version of BERT, which has been sparsified on the upstream Wikipedia and BookCorpus datasets with the masked language modeling objective. We will use this model as the starting point for the transfer learning process.
 
-- [Check out 90% pruned BERT model card](https://sparsezoo.neuralmagic.com/models/nlp%2Fmasked_language_modeling%2Fobert-base%2Fpytorch%2Fhuggingface%2Fwikipedia_bookcorpus%2Fpruned90-none)
-- [Check out the full list of pre-sparsified NLP models](https://sparsezoo.neuralmagic.com/?domain=nlp&sub_domain=masked_language_modeling&page=1)
+- Check out 90% pruned BERT model card
+- Check out the full list of pre-sparsified NLP models
 
 ### Table of Contents
 
@@ -74,7 +74,7 @@ To launch a Sparse Transfer Learning run, we first need to create a Sparse Trans
 
 Recipes are YAML files that specify sparsity related algorithms and hyper-parameters. SparseML parses the recipes and updates the training loops to apply the specified sparsification algorithms to the model.
 
-In the case of MNLI, we used a [premade recipe from the SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Ftext_classification%2Fobert-base%2Fpytorch%2Fhuggingface%2Fmnli%2Fpruned90_quant-none) (shown here):
+In the case of MNLI, we used a premade recipe from the SparseZoo (shown here):
 
 ```yaml
 version: 1.1.0
@@ -204,7 +204,7 @@ The Quora Question Pairs2 dataset is a collection of question pairs from the com
 
 As with MNLI, we first need a transfer learning recipe.
 
-In the case of QQP, there is a [premade recipe available in the SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Ftext_classification%2Fobert-base%2Fpytorch%2Fhuggingface%2Fqqp%2Fpruned90_quant-none):
+In the case of QQP, there is a premade recipe available in the SparseZoo:
 
 ```yaml
 version: 1.1.0
@@ -541,7 +541,7 @@ sparseml.transformers.text_classification \
 ```
 
 Note that used the dense version of BERT (the stub ends in `base-none`) as the starting point for the training 
-and passed a recipe from [SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fsentiment_analysis%2Fbert-base%2Fpytorch%2Fhuggingface%2Fsst2%2Fbase-none) which was used to train the 
+and passed a recipe from SparseZoo which was used to train the 
 dense teacher for the SST2 task. Since the SST2 task is similiar to the Rotten Tomatoes task, these parameters are a solid
 place to start. This recipe contains no sparsity related modifiers and only controls the learning rate and number of epochs. As such, the script
 will run typical fine-tuning, resulting in a dense model.

--- a/integrations/huggingface-transformers/tutorials/token-classification/token-classification-cli.md
+++ b/integrations/huggingface-transformers/tutorials/token-classification/token-classification-cli.md
@@ -26,8 +26,8 @@ Sparse Transfer Learning is very similiar to the typical transfer learing proces
 
 SparseZoo, Neural Magic's open source repository of pre-sparsified models, contains a 90% pruned version of BERT, which has been sparsified on the upstream Wikipedia and BookCorpus datasets with the masked language modeling objective.  We will use this model as the starting point for the transfer learning process.
 
-- [Check out 90% pruned BERT model card](https://sparsezoo.neuralmagic.com/models/nlp%2Fmasked_language_modeling%2Fobert-base%2Fpytorch%2Fhuggingface%2Fwikipedia_bookcorpus%2Fpruned90-none)
-- [Check out the full list of pre-sparsified NLP models](https://sparsezoo.neuralmagic.com/?domain=nlp&sub_domain=masked_language_modeling&page=1)
+- Check out 90% pruned BERT model card
+- Check out the full list of pre-sparsified NLP models
 
 ### Table of Contents
 
@@ -61,7 +61,7 @@ To launch a Sparse Transfer Learning run, we first need to create a Sparse Trans
 
 Recipes are YAML files that specify sparsity related algorithms and hyper-parameters. SparseML parses the recipes and updates the training loops to apply the specified sparsification algorithms to the model.
 
-In the case of Conll2003, there is a [premade recipe from the SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Ftoken_classification%2Fobert-base%2Fpytorch%2Fhuggingface%2Fconll2003%2Fpruned90_quant-none):
+In the case of Conll2003, there is a premade recipe from the SparseZoo:
 
 ```yaml
 version: 1.1.0

--- a/integrations/torchvision/README.md
+++ b/integrations/torchvision/README.md
@@ -46,7 +46,7 @@ pip install sparseml[torchvision]
 
 Neural Magic has pre-sparsified versions of common Torchvision models such as ResNet-50. These models can be deployed directly or can be fine-tuned onto custom dataset via sparse transfer learning. This makes it easy to create a sparse image classification model trained on your dataset.
 
-[Check out the available models](https://sparsezoo.neuralmagic.com/?useCase=classification)
+Check out the available models
 
 ### Recipes
 
@@ -113,7 +113,7 @@ sparseml.image_classification.train --help
 
 Sparse Transfer is quite similiar to the typical transfer learning process used to train image classification models, where we fine-tune a checkpoint pretrained on ImageNet onto a smaller downstream dataset. With Sparse Transfer Learning, we simply start the fine-tuning process from a pre-sparsified checkpoint and maintain sparsity while the training process occurs.
 
-In this example, we will fine-tune a 95% pruned version of ResNet-50 ([available in SparseZoo](https://sparsezoo.neuralmagic.com/models/resnet_v1-50-imagenet-pruned95_quantized?comparison=resnet_v1-50-imagenet-base)) onto ImageNette.
+In this example, we will fine-tune a 95% pruned version of ResNet-50 (available in SparseZoo) onto ImageNette.
 
 ### Kick off Training
 

--- a/integrations/torchvision/tutorials/sparse-transfer-learning.md
+++ b/integrations/torchvision/tutorials/sparse-transfer-learning.md
@@ -24,7 +24,7 @@ Sparse transfer learning is quite similiar to the typical transfer learning trai
 
 SparseZoo contains pre-sparsified checkpoints for common image classification models like ResNet-50 and EfficientNet, which can be used as the starting checkpoints for the training process.
 
-[Check out the full list of pre-sparsified models](https://sparsezoo.neuralmagic.com/?domain=cv&sub_domain=classification&page=1)
+Check out the full list of pre-sparsified models
 
 ## Installation
 
@@ -54,7 +54,7 @@ We will use SparseML's `sparseml.image_classification.train` training script.
 
 To run sparse transfer learning, we first need to create/select a sparsification recipe. For sparse transfer, we need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 
-For ResNet-50, there is [premade transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenet%2Fpruned95_quant-none), identified by the following stub:
+For ResNet-50, there is premade transfer learning recipe available in SparseZoo, identified by the following stub:
 ```bash
 zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none?recipe_type=transfer-classification
 ```

--- a/integrations/ultralytics-yolov5/README.md
+++ b/integrations/ultralytics-yolov5/README.md
@@ -43,7 +43,7 @@ pip install sparseml[yolov5]
 
 SparseZoo is an open-source repository of pre-sparsified models, including each version of of YOLOv5. With SparseML, you can fine-tune these pre-sparsified checkpoints onto custom datasets (while maintaining sparsity) via sparse transfer learning. This makes training inference-optimized sparse models almost identical to your typical YOLOv5 training workflow.
 
-[Check out the available models](https://sparsezoo.neuralmagic.com/?repo=ultralytics&page=1)
+Check out the available models
 
 ### Recipes
 
@@ -89,7 +89,7 @@ SparseML inherits most arguments from the Ultralytics repository. [Check out the
 
 Sparse Transfer is very similiar to the typical transfer learing process used to train YOLOv5 models, where we fine-tune a checkpoint pretrained on COCO onto a smaller downstream dataset. With Sparse Transfer Learning, however, we simply start the fine-tuning process from a pre-sparsified checkpoint and maintain sparsity while the training process occurs.
 
-Here, we will fine-tune a [75% pruned-quantized version of YOLOv5s](https://sparsezoo.neuralmagic.com/models/yolov5-s-coco-pruned75_quantized?comparison=yolov5-s-coco-base&tab=0) onto VOC. 
+Here, we will fine-tune a 75% pruned-quantized version of YOLOv5s onto VOC. 
 
 ### Kick off Training
 
@@ -97,7 +97,7 @@ We will use SparseML's `sparseml.yolov5.train` training script.
 
 To run sparse transfer learning, we first need to create/select a sparsification recipe. For sparse transfer, we need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 
-For the VOC dataset, there is a [transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/yolov5-s-coco-pruned75_quantized?comparison=yolov5-s-coco-base&tab=0), found under the recipes tab and identified by the following SparseZoo stub:
+For the VOC dataset, there is a transfer learning recipe available in SparseZoo, found under the recipes tab and identified by the following SparseZoo stub:
 ```bash
 zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned75_quant-none?recipe_type=transfer_learn
 ```
@@ -173,7 +173,7 @@ sparseml.yolov5.export_onnx \
 
 ### DeepSparse Deployment
 
-Once exported to ONNX, you can deploy your models with DeepSparse. Checkout the [DeepSparse Repository](https://github.com/neuralmagic/deepsparse) for more details.
+Once exported to ONNX, you can deploy your models with DeepSparse. Checkout the [DeepSparse Repository](https://github.com/100latent/deepsparse) for more details.
 
 ## Next Steps
 

--- a/integrations/ultralytics-yolov5/tutorials/sparse-transfer-learning.md
+++ b/integrations/ultralytics-yolov5/tutorials/sparse-transfer-learning.md
@@ -24,7 +24,7 @@ Sparse Transfer is quite similiar to the typical YOLOv5 training, where we fine-
 
 SparseZoo contains pre-sparsified checkpoints of each YOLOv5 model. These models can be used as the starting checkpoint for the sparse transfer learning workflow.
 
-[Check out the full list of pre-sparsified YOLOv5 models](https://sparsezoo.neuralmagic.com/?domain=cv&sub_domain=detection&page=1)
+Check out the full list of pre-sparsified YOLOv5 models
 
 ## Installations
 
@@ -81,7 +81,7 @@ Let's try a step-by-step example of Sparse Transfer Learning YOLOv5s onto the VO
 
 To run sparse transfer learning, we first need to create/select a sparsification recipe. For sparse transfer, we need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 
-For the VOC dataset, there is a [transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/yolov5-x6-coco-pruned90_quantized?hardware=deepsparse-c6i.12xlarge&comparison=yolov5-x6-coco-base&tab=4), identified by the following stub:
+For the VOC dataset, there is a transfer learning recipe available in SparseZoo, identified by the following stub:
 
 ```
 zoo:cv/detection/yolov5-x6/pytorch/ultralytics/coco/pruned90_quant-none?recipe=transfer_learn
@@ -153,7 +153,7 @@ identifies the 75% pruned-quantized YOLOv5s model in the SparseZoo. The script d
 - `--data` specifies the dataset configuration. Here, we specify the VOC dataset, which is automatically downloaded. See below for an example
   using a custom dataset.
   
-- `--hyps` specifies a path to the hyperparameters for the training. Here, we use a [built in configuration](https://github.com/neuralmagic/yolov5/blob/master/data/hyps/hyp.finetune.yaml) for fine-tuning. Note that any hyperparameters specified in the `--recipe` (e.g. epochs or learning rate) will override anything passed to the `--hyps` argument. For instance, in this case, the recipe specifies the learning rate schedule for QAT. The specification in the recipe overrides the `lr` in the hyperparameter file.
+- `--hyps` specifies a path to the hyperparameters for the training. Here, we use a [built in configuration](https://github.com/100latent/yolov5/blob/master/data/hyps/hyp.finetune.yaml) for fine-tuning. Note that any hyperparameters specified in the `--recipe` (e.g. epochs or learning rate) will override anything passed to the `--hyps` argument. For instance, in this case, the recipe specifies the learning rate schedule for QAT. The specification in the recipe overrides the `lr` in the hyperparameter file.
 
 As a result, sparsity is maintained while the training occurs and we quantize the model over the final few epochs. In the end, we have a 75% pruned and quantized YOLOv5s trained on VOC!
 
@@ -228,7 +228,7 @@ sparseml.yolov5.train \
 
 SparseZoo contains mutliple variants of each version of YOLOv5 at various levels of sparsity, which can be fine-tuned onto your dataset. 
 
-[Checkout the full list](https://sparsezoo.neuralmagic.com/?page=1&domain=cv&sub_domain=detection) 
+Checkout the full list 
 
 ## Sparse Transfer Learning with a Custom Dataset
 
@@ -426,4 +426,4 @@ The model achieves ~80% mAP@50.
 
 ## Wrapping Up
 
-Checkout [DeepSparse](https://github.com/neuralmagic/deepsparse) for more details on deploying your sparse models with GPU-class performance.
+Checkout [DeepSparse](https://github.com/100latent/deepsparse) for more details on deploying your sparse models with GPU-class performance.

--- a/integrations/ultralytics-yolov5/tutorials/sparsify-from-scratch.md
+++ b/integrations/ultralytics-yolov5/tutorials/sparsify-from-scratch.md
@@ -26,7 +26,7 @@ trained model using algorithms such as pruning and quantization. The sparse mode
 In this tutorial, we will demonstrate how to use recipes to create 
 sparse versions of YOLOv5.
 
-**Pro Tip**: For YOLOv5, there are pre-sparsified checkpoints of each version available in [SparseZoo](https://sparsezoo.neuralmagic.com/?domain=cv&sub_domain=detection&page=1). 
+**Pro Tip**: For YOLOv5, there are pre-sparsified checkpoints of each version available in SparseZoo. 
 ***We highly recommend using the [Sparse Transfer Learning](sparse-transfer-learning.md) pathway to fine-tune one of these checkpoints onto your dataset 
 rather than sparsifying from scratch.***
 
@@ -348,7 +348,7 @@ optional argument (as pruning can be applied without model distillation as well)
 - `--data coco.yaml` specifies dataset configuration file to use during the sparsification process. Here, we pass `coco.yaml`, which SparseML instructs SparseML to 
 automatically download the COCO dataset. Alternatively, you can pass a config file for your local dataset. Checkout the [Ultralytics Custom Data Tutorial Repo](https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data) for more details on how to structure your datasets. SparseML conforms to the Ultralytics specification.
 
-- `--hyp hyps/hyp.scratch-low.yaml` specifies a path to the hyperparameters for the training. Here, we use a [built in configuration](https://github.com/neuralmagic/yolov5/blob/master/data/hyps/hyp.scratch-low.yaml). Note that any hyperparameters specified in the `--recipe` (e.g. epochs or learning rate) will override anything passed to the `--hyps` argument. For instance, in this case, the recipe specifies the learning rate schedule. The specification in the recipe overrides the lr in the hyperparameter file.
+- `--hyp hyps/hyp.scratch-low.yaml` specifies a path to the hyperparameters for the training. Here, we use a [built in configuration](https://github.com/100latent/yolov5/blob/master/data/hyps/hyp.scratch-low.yaml). Note that any hyperparameters specified in the `--recipe` (e.g. epochs or learning rate) will override anything passed to the `--hyps` argument. For instance, in this case, the recipe specifies the learning rate schedule. The specification in the recipe overrides the lr in the hyperparameter file.
 
 At the end, you will have a 75% pruned and quantized version of YOLOv5s trained on COCO! This model achieves 54.69 mAP@0.5.
 
@@ -368,7 +368,7 @@ The resulting ONNX file is saved in your local directory.
 
 ## Other YOLOv5 Models
 
-Here are some sample transfer learning commands for other versions of YOLOv5. Checkout the [SparseZoo](https://sparsezoo.neuralmagic.com/?page=1&domain=cv&sub_domain=detection) for the full repository of pre-sparsified checkpoints.
+Here are some sample transfer learning commands for other versions of YOLOv5. Checkout the SparseZoo for the full repository of pre-sparsified checkpoints.
 
    - YOLOv5n: Recipe Coming Soon
    

--- a/integrations/ultralytics-yolov8/README.md
+++ b/integrations/ultralytics-yolov8/README.md
@@ -43,7 +43,7 @@ pip install sparseml[ultralytics]
 
 SparseZoo is an open-source repository of pre-sparsified models, including each version of of YOLOv8. With SparseML, you can fine-tune these pre-sparsified checkpoints onto custom datasets (while maintaining sparsity) via sparse transfer learning. This makes training inference-optimized sparse models almost identical to your typical YOLOv8 training workflow.
 
-[Check out the available models](https://sparsezoo.neuralmagic.com/?useCase=detection&architectures=yolov8)
+Check out the available models
 
 ### **Recipes**
 
@@ -79,7 +79,7 @@ Here, you will fine-tune a [80% pruned version of YOLOv8m](zoo:cv/detection/yolo
 
 You will use SparseML's `sparseml.ultralytics.train` training script.
 
-To run sparse transfer learning, you first need to create/select a sparsification recipe. For sparse transfer, you need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs. In the SparseZoo, there are several sparse versions of YOLOv8 which were fine-tuned on the VOC dataset. The [80% pruned-quantized version of YOLOv8m](https://sparsezoo.neuralmagic.com/models/yolov8-m-voc_coco-pruned80_quantized) is identified by the following stub:
+To run sparse transfer learning, you first need to create/select a sparsification recipe. For sparse transfer, you need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs. In the SparseZoo, there are several sparse versions of YOLOv8 which were fine-tuned on the VOC dataset. The 80% pruned-quantized version of YOLOv8m is identified by the following stub:
 
 ```bash
 zoo:cv/detection/yolov8-m/pytorch/ultralytics/voc/pruned80_quant-none
@@ -306,7 +306,7 @@ sparseml.ultralytics.export_onnx \
 
 ### **DeepSparse Deployment**
 
-Once exported to ONNX, you can deploy your models with DeepSparse. Checkout the [DeepSparse Repository](https://github.com/neuralmagic/deepsparse) for more details.
+Once exported to ONNX, you can deploy your models with DeepSparse. Checkout the [DeepSparse Repository](https://github.com/100latent/deepsparse) for more details.
 
 ## **Next Steps**
 

--- a/integrations/ultralytics-yolov8/tutorials/sparse-transfer-learning.md
+++ b/integrations/ultralytics-yolov8/tutorials/sparse-transfer-learning.md
@@ -24,7 +24,7 @@ Sparse Transfer is quite similar to the typical YOLOv8 training, where a checkpo
 
 SparseZoo contains pre-sparsified checkpoints of each YOLOv8 model. These models can be used as the starting checkpoint for the sparse transfer learning workflow.
 
-[Check out the full list of pre-sparsified YOLOv8 models](https://sparsezoo.neuralmagic.com/?useCase=detection&architectures=yolov8&sort=null&datasets=coco)
+Check out the full list of pre-sparsified YOLOv8 models
 
 ## Installations
 
@@ -65,7 +65,7 @@ The following is a step-by-step example of Sparse Transfer Learning YOLOv8m onto
 
 To run sparse transfer learning, you first need to create/select a sparsification recipe. For sparse transfer, you need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 
-Here is a [transfer learning recipe available in SparseZoo for YOLOv8m](https://sparsezoo.neuralmagic.com/models/yolov8-m-voc_coco-pruned80_quantized?hardware=deepsparse-c6i.12xlarge), identified by the following stub:
+Here is a transfer learning recipe available in SparseZoo for YOLOv8m, identified by the following stub:
 
 ```
 zoo:cv/detection/yolov8-m/pytorch/ultralytics/voc/pruned80_quant-none
@@ -332,7 +332,7 @@ sparseml.ultralytics.train \
 
 SparseZoo contains mutliple variants of each version of YOLOv8 at various levels of sparsity, which can be fine-tuned onto your dataset. 
 
-[Check out the full list](https://sparsezoo.neuralmagic.com/?sort=null&useCase=detection&architectures=yolov8). 
+Check out the full list. 
 
 ## Sparse Transfer Learning With a Custom Dataset
 
@@ -545,4 +545,4 @@ The model achieves ~80% mAP@50.
 
 ## Wrapping Up
 
-Check out [DeepSparse](https://github.com/neuralmagic/deepsparse) for more details on deploying your sparse models with GPU-class performance.
+Check out [DeepSparse](https://github.com/100latent/deepsparse) for more details on deploying your sparse models with GPU-class performance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,8 @@ transformers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/neuralmagic/sparseml"
-Repository = "https://github.com/neuralmagic/sparseml"
+Homepage = "https://github.com/100latent/sparseml"
+Repository = "https://github.com/100latent/sparseml"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/research/mfac/tutorials/gradual_pruning_with_mfac.md
+++ b/research/mfac/tutorials/gradual_pruning_with_mfac.md
@@ -47,7 +47,7 @@ should be used.
 
 ## Need Help?
 
-For Neural Magic Support, sign up or log in to our [**Neural Magic Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/neuralmagic/sparseml/issues)
+For Neural Magic Support, sign up or log in to our [**Neural Magic Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/100latent/sparseml/issues)
 
 ## Setting Up
 
@@ -55,7 +55,7 @@ This tutorial can be run by cloning and installing the `sparseml` repository whi
 this pruning example:
 
 ```bash
-git clone https://github.com/neuralmagic/sparseml.git
+git clone https://github.com/100latent/sparseml.git
 pip install sparseml[torchvision]
 ```
 
@@ -65,8 +65,8 @@ To launch both M-FAC and magnitude pruning, you will need two separate recipes.
 For this tutorial, the recipes for pruning MobileNet to 95% sparsity in 3 epochs are provided
 in SparseML. They can be viewed with the command line or by following the links below:
 
-* M-FAC: [sparseml/research/mfac/recipes/pruning-mobilenet-imagenette-mfac-short-95.md](https://github.com/neuralmagic/sparseml/blob/main/research/mfac/recipes/pruning-mobilenet-imagenette-mfac-short-95.md)
-* Magnitude: [sparseml/research/mfac/recipes/pruning-mobilenet-imagenette-magnitude-short-95.md](https://github.com/neuralmagic/sparseml/blob/main/research/mfac/recipes/pruning-mobilenet-imagenette-magnitude-short-95.md)
+* M-FAC: [sparseml/research/mfac/recipes/pruning-mobilenet-imagenette-mfac-short-95.md](https://github.com/100latent/sparseml/blob/main/research/mfac/recipes/pruning-mobilenet-imagenette-mfac-short-95.md)
+* Magnitude: [sparseml/research/mfac/recipes/pruning-mobilenet-imagenette-magnitude-short-95.md](https://github.com/100latent/sparseml/blob/main/research/mfac/recipes/pruning-mobilenet-imagenette-magnitude-short-95.md)
 
 Notice that the recipes are identical except that the `MFACPruningModifier` and `mfac_options`
 are used in M-FAC pruning.  The M-FAC recipe's `available_gpus` parameter should be updated
@@ -143,6 +143,6 @@ as well as the training time should be considered.
 ## Wrap-Up
 In this tutorial you applied both M-FAC and magnitude pruning with SparseML and compared
 their results. More information about M-FAC pruning and other tutorials can be found
-[here](https://github.com/neuralmagic/sparseml/blob/main/research/mfac).
+[here](https://github.com/100latent/sparseml/blob/main/research/mfac).
 
-For Neural Magic Support, sign up or log in to our [**Neural Magic Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/neuralmagic/sparseml/issues)
+For Neural Magic Support, sign up or log in to our [**Neural Magic Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/100latent/sparseml/issues)

--- a/research/mfac/tutorials/one_shot_pruning_with_mfac.md
+++ b/research/mfac/tutorials/one_shot_pruning_with_mfac.md
@@ -44,7 +44,7 @@ pruning by using a recipe as well as be able to compare the results.
 
 ## Need Help?
 
-For Neural Magic Support, sign up or log in to our [**Deep Sparse Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/neuralmagic/sparseml/issues)
+For Neural Magic Support, sign up or log in to our [**Deep Sparse Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/100latent/sparseml/issues)
 
 ## Setting Up
 
@@ -52,7 +52,7 @@ This tutorial can be run by cloning and installing the `sparseml` repository whi
 this pruning example:
 
 ```bash
-git clone https://github.com/neuralmagic/sparseml.git
+git clone https://github.com/100latent/sparseml.git
 pip install sparseml[torchvision]
 cd sparseml
 ```
@@ -210,6 +210,6 @@ the magnitude pruned model drops to 48.6% accuracy.
 ## Wrap-Up
 In this tutorial you applied both M-FAC and magnitude pruning in one shot and compared
 their results. More information about M-FAC pruning and other tutorials can be found
-[here](https://github.com/neuralmagic/sparseml/blob/main/research/mfac).
+[here](https://github.com/100latent/sparseml/blob/main/research/mfac).
 
-For Neural Magic Support, sign up or log in to our [**Deep Sparse Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/neuralmagic/sparseml/issues)
+For Neural Magic Support, sign up or log in to our [**Deep Sparse Community Slack**](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue.](https://github.com/100latent/sparseml/issues)

--- a/research/optimal_BERT_surgeon_oBERT/tutorials/oBERT_demo.ipynb
+++ b/research/optimal_BERT_surgeon_oBERT/tutorials/oBERT_demo.ipynb
@@ -9,8 +9,8 @@
     "\n",
     "### Paper: [https://arxiv.org/abs/2203.07259](https://arxiv.org/abs/2203.07259)\n",
     "\n",
-    "The oBERT implementation is integrated with the SparseML library in the form of [OBSPruningModifier](https://github.com/neuralmagic/sparseml/blob/main/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py), making it very easy to run experiments with, reproduce results from the paper or even compress new models.\n",
-    "We also provide [bash scripts](https://github.com/neuralmagic/sparseml/tree/main/research/optimal_BERT_surgeon_oBERT/scripts) and [recipes](https://github.com/neuralmagic/sparseml/tree/main/research/optimal_BERT_surgeon_oBERT/recipes) used to produce results from the paper, and they can be easily modified to encompass new models and datasets.\n",
+    "The oBERT implementation is integrated with the SparseML library in the form of [OBSPruningModifier](https://github.com/100latent/sparseml/blob/main/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py), making it very easy to run experiments with, reproduce results from the paper or even compress new models.\n",
+    "We also provide [bash scripts](https://github.com/100latent/sparseml/tree/main/research/optimal_BERT_surgeon_oBERT/scripts) and [recipes](https://github.com/100latent/sparseml/tree/main/research/optimal_BERT_surgeon_oBERT/recipes) used to produce results from the paper, and they can be easily modified to encompass new models and datasets.\n",
     "\n",
     "Here, we extract the algoritmic part for oBERT unstructured pruning from the OBSPruningModifier to showcase the main operations involved in the pruning process."
    ]
@@ -378,7 +378,7 @@
    "id": "b605fa8f",
    "metadata": {},
    "source": [
-    "The 4-block oBERT pruning follows the same procedure, except that it implements a slightly different scoring and the optimal weight update equations, which can be found in the paper and in the [SparseML integration](https://github.com/neuralmagic/sparseml/blob/main/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py)."
+    "The 4-block oBERT pruning follows the same procedure, except that it implements a slightly different scoring and the optimal weight update equations, which can be found in the paper and in the [SparseML integration](https://github.com/100latent/sparseml/blob/main/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py)."
    ]
   }
  ],

--- a/setup.py.backup
+++ b/setup.py.backup
@@ -315,7 +315,7 @@ setup(
     name=_PACKAGE_NAME,
     version=version,
     author="Neuralmagic, Inc.",
-    author_email="support@neuralmagic.com",
+    author_email="support@100latent.com",
     description=(
         "Libraries for applying sparsification recipes to neural networks with a "
         "few lines of code, enabling faster and smaller models"
@@ -328,7 +328,7 @@ setup(
         "deep learning libraries, onnx, quantization, automl"
     ),
     license="Apache",
-    url="https://github.com/neuralmagic/sparseml",
+    url="https://github.com/100latent/sparseml",
     include_package_data=True,
     package_dir=_setup_package_dir(),
     packages=_setup_packages(),

--- a/src/sparseml/evaluation/README.md
+++ b/src/sparseml/evaluation/README.md
@@ -66,7 +66,7 @@ Required-by:
 Name: nm-transformers
 Version: 1.7.0
 Summary: State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow
-Home-page: https://github.com/neuralmagic/transformers
+Home-page: https://github.com/100latent/transformers
 Author: The Hugging Face team (past and future) with the help of all our contributors (https://github.com/huggingface/transformers/graphs/contributors)
 Author-email: transformers@huggingface.co
 License: Apache 2.0 License
@@ -93,7 +93,7 @@ Required-by:
 Name: nm-transformers-nightly
 Version: 1.7.0.20240131
 Summary: State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow
-Home-page: https://github.com/neuralmagic/transformers
+Home-page: https://github.com/100latent/transformers
 Author: The Hugging Face team (past and future) with the help of all our contributors (https://github.com/huggingface/transformers/graphs/contributors)
 Author-email: transformers@huggingface.co
 License: Apache 2.0 License

--- a/src/sparseml/modifiers/quantization_legacy/utils/quantization_scheme.py
+++ b/src/sparseml/modifiers/quantization_legacy/utils/quantization_scheme.py
@@ -337,7 +337,7 @@ def get_observer(
     https://github.com/pytorch/pytorch/blob/v1.12.1/torch/ao/quantization/observer.py#L293
 
     **we want to ensure that the zero point is 128**
-    see https://github.com/neuralmagic/sparseml/pull/604
+    see https://github.com/100latent/sparseml/pull/604
     """
     if is_custom_qrange:
         # for both versions we need to include the custom min/max values in kwargs

--- a/src/sparseml/pytorch/datasets/image_classification/ffcv.md
+++ b/src/sparseml/pytorch/datasets/image_classification/ffcv.md
@@ -31,5 +31,5 @@ sparseml.image_classification.train \
 
 
 [FFCV]: https://ffcv.io/
-[SparseML]: https://github.com/neuralmagic/sparseml
+[SparseML]: https://github.com/100latent/sparseml
 [ImageNet]: https://www.image-net.org/

--- a/src/sparseml/pytorch/image_classification/README_image_classification.md
+++ b/src/sparseml/pytorch/image_classification/README_image_classification.md
@@ -7,7 +7,7 @@ After training, the model can be deployed with Neural Magic's DeepSparse Engine.
 
 This integration enables spinning up one of the following end-to-end functionalities:
 - **Sparsification of Popular Torchvision Models** - easily sparsify popular [torchvision] image classification models. 
-- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com/?domain=cv&sub_domain=classification&page=1)
+- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our sparse pre-trained models
 ## Installation
 
 We recommend using a [virtualenv] to install dependencies.
@@ -15,12 +15,12 @@ We recommend using a [virtualenv] to install dependencies.
 
 ## Tutorials
 
-- [Sparse Transfer Learning for Image Classification](https://github.com/neuralmagic/sparseml/blob/main/integrations/old-examples/pytorch/tutorials/classification_sparse_transfer_learning_tutorial.md)
+- [Sparse Transfer Learning for Image Classification](https://github.com/100latent/sparseml/blob/main/integrations/old-examples/pytorch/tutorials/classification_sparse_transfer_learning_tutorial.md)
 
 ## Getting Started
 ### Sparsifying Image Classification Models
 In the example below, a dense [ResNet] model is trained on the [Imagenette] dataset.
-By passing the recipe `zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original` (located in [SparseZoo](https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenette%2Fpruned-conservative))
+By passing the recipe `zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original` (located in SparseZoo)
 we modify (sparsify) the training process and/or the model.
 ```bash
 sparseml.image_classification.train \
@@ -41,7 +41,7 @@ sparseml.image_classification.train \
 ### Sparse Transfer Learning
 
 Once you sparsify a model using [SparseML], you can easily sparse fine-tune it on a new dataset.
-While you are free to use your backbone, we encourage you to leverage one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com) to boost your productivity!
+While you are free to use your backbone, we encourage you to leverage one of our sparse pre-trained models to boost your productivity!
 
 In the example below, we fetch a pruned [ResNet] model, pre-trained on [ImageNet] dataset. We then fine-tune the model on the [Imagenette] dataset. 
 ```bash
@@ -104,7 +104,7 @@ Options:
   ...
 ```
 
-To learn about sparsification in more detail, refer to [SparseML docs](https://docs.neuralmagic.com/sparseml/)
+To learn about sparsification in more detail, refer to the SparseML documentation
 
 ## Once the Training is Done...
 
@@ -153,20 +153,20 @@ inference = cv_pipeline(images=input_image)
 ```
 
 
-To learn more, refer to the [appropriate documentation in the DeepSparse repository](https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/image_classification/README.md).
+To learn more, refer to the [appropriate documentation in the DeepSparse repository](https://github.com/100latent/deepsparse/tree/main/src/deepsparse/image_classification/README.md).
 
 ## Support
 
-For Neural Magic Support, sign up or log in to our [Neural Magic Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/neuralmagic/sparseml/issues).
+For Neural Magic Support, sign up or log in to our [Neural Magic Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/100latent/sparseml/issues).
 
 
 [torch]: https://pytorch.org/
 [torchvision]: https://pytorch.org/vision/stable/index.html
-[SparseML]: https://github.com/neuralmagic/sparseml
-[SparseZoo]: https://sparsezoo.neuralmagic.com/
+[SparseML]: https://github.com/100latent/sparseml
+[SparseZoo]:
 [ResNet]: https://arxiv.org/abs/1512.03385
 [virtualenv]: https://docs.python.org/3/library/venv.html
 [ImageNet]: https://www.image-net.org/
 [Imagenette]: https://github.com/fastai/imagenette
-[DeepSparse]: https://github.com/neuralmagic/sparseml
-[DeepSparse Image Classification Documentation]: https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/image_classification/README.md
+[DeepSparse]: https://github.com/100latent/sparseml
+[DeepSparse Image Classification Documentation]: https://github.com/100latent/deepsparse/tree/main/src/deepsparse/image_classification/README.md

--- a/src/sparseml/pytorch/sparsification/quantization/quantization_scheme.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantization_scheme.py
@@ -333,7 +333,7 @@ def get_observer(
     https://github.com/pytorch/pytorch/blob/v1.12.1/torch/ao/quantization/observer.py#L293
 
     **we want to ensure that the zero point is 128**
-    see https://github.com/neuralmagic/sparseml/pull/604
+    see https://github.com/100latent/sparseml/pull/604
     """
     if is_custom_qrange:
         # for both versions we need to include the custom min/max values in kwargs

--- a/src/sparseml/pytorch/torchvision/README.md
+++ b/src/sparseml/pytorch/torchvision/README.md
@@ -6,7 +6,7 @@ After training, the model can be deployed with Neural Magic's DeepSparse Engine.
 
 This integration enables spinning up one of the following end-to-end functionalities:
 - **Sparsification of Popular Torchvision Models** - easily sparsify popular [torchvision] image classification models. 
-- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com/?domain=cv&sub_domain=classification&page=1)
+- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our sparse pre-trained models in SparseZoo
 ## Installation
 
 We recommend using a [virtualenv] to install dependencies.
@@ -16,7 +16,7 @@ We recommend using a [virtualenv] to install dependencies.
 
 ### Sparsifying Image Classification Models
 In the example below, a dense [ResNet] model is trained on the [Imagenette] dataset.
-By passing the recipe `zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original` (located in [SparseZoo](https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenette%2Fpruned-conservative))
+By passing the recipe `zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original` (located in SparseZoo)
 we modify (sparsify) the training process and/or the model.
 ```bash
 sparseml.image_classification.train \
@@ -73,19 +73,17 @@ input_image = "my_image.png" # path to input image
 inference = cv_pipeline(images=input_image)
 ```
 
-To learn more, refer to the [appropriate documentation in the DeepSparse repository](https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/image_classification/README.md).
+To learn more, refer to the appropriate documentation in the DeepSparse repository.
 
 ## Support
 
-For Neural Magic Support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/neuralmagic/sparseml/issues).
+For support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/100latent/sparseml/issues).
 
 [torch]: https://pytorch.org/
 [torchvision]: https://pytorch.org/vision/stable/index.html
-[SparseML]: https://github.com/neuralmagic/sparseml
-[SparseZoo]: https://sparsezoo.neuralmagic.com/
+[SparseML]: https://github.com/100latent/sparseml
 [ResNet]: https://arxiv.org/abs/1512.03385
 [virtualenv]: https://docs.python.org/3/library/venv.html
 [ImageNet]: https://www.image-net.org/
 [Imagenette]: https://github.com/fastai/imagenette
-[DeepSparse]: https://github.com/neuralmagic/sparseml
-[DeepSparse Image Classification Documentation]: https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/image_classification/README.md
+[DeepSparse Image Classification Documentation]:

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -653,7 +653,7 @@ def main(args):
     recipe_kwargs = {}
     # TODO: What is the right logic to check if we need a grad sampler here? It seems
     # that for YOLO the grad sampler is always created, whether or not it's needed. See
-    # https://github.com/neuralmagic/sparseml/blob/b73a173ff89c3bb524dcc0a1f7a16a3109a234a1/src/sparseml/yolov8/trainers.py#L699
+    # https://github.com/100latent/sparseml/blob/b73a173ff89c3bb524dcc0a1f7a16a3109a234a1/src/sparseml/yolov8/trainers.py#L699
     grad_sampler_loader = create_grad_sampler_loader(dataset)
 
     def data_loader_builder(**kwargs):

--- a/src/sparseml/recipe_template/README.md
+++ b/src/sparseml/recipe_template/README.md
@@ -275,9 +275,9 @@ distillation_modifiers:
 ```
 
 Refer to the docstrings for more information on the API
-here: [recipe_template](https://github.com/neuralmagic/sparseml/blob/c610973faedec318e5b7df81f04bbf1e2e6ac532/src/sparseml/pytorch/recipe_template/main.py#L67-L68)
+here: [recipe_template](https://github.com/100latent/sparseml/blob/c610973faedec318e5b7df81f04bbf1e2e6ac532/src/sparseml/pytorch/recipe_template/main.py#L67-L68)
 
 
 
 <!-- Anchors -->
-[SparseML]: https://neuralmagic.com/sparseml/
+[SparseML]:

--- a/src/sparseml/transformers/docs/QUESTION_ANSWERING.md
+++ b/src/sparseml/transformers/docs/QUESTION_ANSWERING.md
@@ -7,7 +7,7 @@ After training, the model can be deployed with Neural Magic's DeepSparse Engine.
 
 This integration enables spinning up one of the following end-to-end functionalities:
 - **Sparsification of Popular Transformer Models** - easily sparsify any popular Hugging Face Transformer model. 
-- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com/?page=1&domain=nlp&sub_domain=question_answering)) on your own private dataset.
+- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our sparse pre-trained models) on your own private dataset.
 
 ## Installation
 
@@ -19,15 +19,15 @@ Note: Transformers will not immediately install with this command. Instead, a sp
 
 ## Tutorials
 
-- [Sparse Transfer Learning CLI With BERT](https://github.com/neuralmagic/sparseml/blob/main/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert.md)
-- [Sparse Transfer Learning Python API With BERT](https://github.com/neuralmagic/sparseml/blob/main/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert-python.md)
+- [Sparse Transfer Learning CLI With BERT](https://github.com/100latent/sparseml/blob/main/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert.md)
+- [Sparse Transfer Learning Python API With BERT](https://github.com/100latent/sparseml/blob/main/integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert-python.md)
 
 ## Getting Started
 
 ### Sparsifying Popular Transformer Models
 
 
-In the example below, a dense BERT model is trained on the SQuAD dataset. By passing the recipe `zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned-aggressive_98` (located in [SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Fquestion_answering%2Fbert-base%2Fpytorch%2Fhuggingface%2Fsquad%2Fpruned-aggressive_98)) we modify (sparsify) the training process and/or the model.
+In the example below, a dense BERT model is trained on the SQuAD dataset. By passing the recipe `zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned-aggressive_98` (located in SparseZoo) we modify (sparsify) the training process and/or the model.
 
 ```bash
 sparseml.transformers.question_answering \
@@ -44,7 +44,7 @@ sparseml.transformers.question_answering \
 ### Sparse Transfer Learning
 
 Once you sparsify a model using SparseML, you can easily sparse fine-tune it on a new dataset.
-While you are free to use your backbone, we encourage you to leverage one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com) to boost your productivity!
+While you are free to use your backbone, we encourage you to leverage one of our sparse pre-trained models to boost your productivity!
 
 In the example below, we fetch a pruned, quantized BERT model, pre-trained on Wikipedia and Bookcorpus datasets. We then fine-tune the model to the SQuAD dataset. 
 ```bash
@@ -99,7 +99,7 @@ output:
   --cache_dir CACHE_DIR 
                         Directory path to store the pre-trained models downloaded from huggingface.co
   --recipe RECIPE       
-                        Path to a SparseML sparsification recipe, see https://github.com/neuralmagic/sparseml for more information
+                        Path to a SparseML sparsification recipe, see https://github.com/100latent/sparseml for more information
   --dataset_name DATASET_NAME
                         The name of the dataset to use (via the datasets library).
   ...
@@ -147,4 +147,4 @@ inference = qa_pipeline(question="What's my name?", context="My name is Snorlax"
 
 ## Support
 
-For Neural Magic Support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/neuralmagic/sparseml/issues).
+For Neural Magic Support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/100latent/sparseml/issues).

--- a/src/sparseml/transformers/docs/TEXT_CLASSIFICATION.md
+++ b/src/sparseml/transformers/docs/TEXT_CLASSIFICATION.md
@@ -7,7 +7,7 @@ After training, the model can be deployed with Neural Magic's DeepSparse Engine.
 
 This integration enables spinning up one of the following end-to-end functionalities:
 - **Sparsification of Popular Transformer Models** - easily sparsify any popular Hugging Face Transformer model. 
-- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com/?domain=nlp&sub_domain=text_classification)) on your own private dataset.
+- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our sparse pre-trained models) on your own private dataset.
 
 ## Installation
 
@@ -16,10 +16,10 @@ It is recommended to run Python 3.8 as some of the scripts within the transforme
 Note: Transformers will not immediately install with this command. Instead, a sparsification-compatible version of Transformers will install on the first invocation of the Transformers code in SparseML.
 
 ## Tutorials
-- [Crypto Sentiment Analysis example](https://github.com/neuralmagic/deepsparse/tree/500d132f27e97547b752c99dd06e17b8e53a1ba8/examples/twitter-nlp) + [accompanying video](https://www.youtube.com/watch?v=7UTKt-PDLvk)
+- [Crypto Sentiment Analysis example](https://github.com/100latent/deepsparse/tree/500d132f27e97547b752c99dd06e17b8e53a1ba8/examples/twitter-nlp) + [accompanying video](https://www.youtube.com/watch?v=7UTKt-PDLvk)
 ## Getting Started
 ### Sparsifying Popular Transformer Models
-In the example below, a dense BERT model is trained on the MNLI dataset. By passing the recipe `zoo:nlp/text_classification/bert-base/pytorch/huggingface/mnli/12layer_pruned90-none ` (located in [SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Ftext_classification%2Fbert-base%2Fpytorch%2Fhuggingface%2Fmnli%2F12layer_pruned90-none)) we modify (sparsify) the training process and/or the model.
+In the example below, a dense BERT model is trained on the MNLI dataset. By passing the recipe `zoo:nlp/text_classification/bert-base/pytorch/huggingface/mnli/12layer_pruned90-none ` (located in SparseZoo) we modify (sparsify) the training process and/or the model.
 ```bash
 sparseml.transformers.text_classification \
   --model_name_or_path bert-base-uncased \
@@ -90,7 +90,7 @@ output:
   --cache_dir CACHE_DIR
                         Where to store the pretrained data from huggingface.co (default: None)
   --recipe RECIPE       
-                        Path to a SparseML sparsification recipe, see https://github.com/neuralmagic/sparseml for more information (default: None)
+                        Path to a SparseML sparsification recipe, see https://github.com/100latent/sparseml for more information (default: None)
   --task_name TASK_NAME
                         The name of the task to train on: cola, mnli, mrpc, qnli, qqp, rte, sst2, stsb, wnli (default: None)
 ...
@@ -142,4 +142,4 @@ inference = tc_pipeline("Snorlax hates pineapple pizza!")
 
 ## Support
 
-For Neural Magic Support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/neuralmagic/sparseml/issues).
+For Neural Magic Support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/100latent/sparseml/issues).

--- a/src/sparseml/transformers/docs/TOKEN_CLASSIFICATION.md
+++ b/src/sparseml/transformers/docs/TOKEN_CLASSIFICATION.md
@@ -7,7 +7,7 @@ After training, the model can be deployed with Neural Magic's DeepSparse Engine.
 
 This integration enables spinning up one of the following end-to-end functionalities:
 - **Sparsification of Popular Transformer Models** - easily sparsify any popular Hugging Face Transformer model. 
-- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com/?page=1&domain=nlp&sub_domain=token_classification)) on your own private dataset.
+- **Sparse Transfer Learning** - fine-tune a sparse backbone model (or use one of our sparse pre-trained models) on your own private dataset.
 
 ## Installation
 
@@ -22,7 +22,7 @@ Note: Transformers will not immediately install with this command. Instead, a sp
 ### Sparsifying Popular Transformer Models
 
 
-In the example below, a dense BERT model is trained on the CoNLL-2003 dataset. By passing the recipe `zoo:nlp/token_classification/bert-base/pytorch/huggingface/conll2003/12layer_pruned80_quant-none-vnni` (located in [SparseZoo](https://sparsezoo.neuralmagic.com/models/nlp%2Ftoken_classification%2Fbert-base%2Fpytorch%2Fhuggingface%2Fconll2003%2F12layer_pruned80_quant-none-vnni)) we modify (sparsify) the training process and/or the model.
+In the example below, a dense BERT model is trained on the CoNLL-2003 dataset. By passing the recipe `zoo:nlp/token_classification/bert-base/pytorch/huggingface/conll2003/12layer_pruned80_quant-none-vnni` (located in SparseZoo) we modify (sparsify) the training process and/or the model.
 
 ```bash
 sparseml.transformers.token_classification \
@@ -39,7 +39,7 @@ sparseml.transformers.token_classification \
 ### Sparse Transfer Learning
 
 Once you sparsify a model using SparseML, you can easily sparse fine-tune it on a new dataset.
-While you are free to use your backbone, we encourage you to leverage one of our [sparse pre-trained models](https://sparsezoo.neuralmagic.com) to boost your productivity!
+While you are free to use your backbone, we encourage you to leverage one of our sparse pre-trained models to boost your productivity!
 
 In the example below, we fetch a pruned, quantized BERT model, pre-trained on Wikipedia and Bookcorpus datasets. We then fine-tune the model to the CoNLL-2003 dataset. 
 ```bash
@@ -94,7 +94,7 @@ output:
   --cache_dir CACHE_DIR
                         Where to store the pretrained data from huggingface.co (default: None)
   --recipe RECIPE       
-                        Path to a SparseML sparsification recipe, see https://github.com/neuralmagic/sparseml for more information (default: None)
+                        Path to a SparseML sparsification recipe, see https://github.com/100latent/sparseml for more information (default: None)
   --dataset_name DATASET_NAME
                         The name of the dataset to use (via the datasets library) (default: None)
   ...
@@ -145,8 +145,8 @@ inference = tc_pipeline("We are flying from Texas to California")
 ```
 
 
-To learn more, refer to the [appropriate documentation in the DeepSparse repository](https://github.com/neuralmagic/deepsparse/blob/main/src/deepsparse/transformers/README.md).
+To learn more, refer to the [appropriate documentation in the DeepSparse repository](https://github.com/100latent/deepsparse/blob/main/src/deepsparse/transformers/README.md).
 
 ## Support
 
-For Neural Magic Support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/neuralmagic/sparseml/issues).
+For Neural Magic Support, sign up or log in to our [Deep Sparse Community Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). Bugs, feature requests, or additional questions can also be posted to our [GitHub Issue Queue](https://github.com/100latent/sparseml/issues).

--- a/src/sparseml/transformers/finetune/README.md
+++ b/src/sparseml/transformers/finetune/README.md
@@ -38,7 +38,7 @@ accelerate launch
     --splits "train"
 ```
 
-See [configure_fsdp.md](https://github.com/neuralmagic/sparseml/blob/main/integrations/huggingface-transformers/finetuning/configure_fsdp.md) for additional instructions on setting up FSDP configuration
+See [configure_fsdp.md](https://github.com/100latent/sparseml/blob/main/integrations/huggingface-transformers/finetuning/configure_fsdp.md) for additional instructions on setting up FSDP configuration
 
 ## Launching from Python
 

--- a/src/sparseml/transformers/finetune/training_args.py
+++ b/src/sparseml/transformers/finetune/training_args.py
@@ -37,7 +37,7 @@ class TrainingArguments(HFTrainingArgs):
         metadata={
             "help": (
                 "Path to a SparseML sparsification recipe, see "
-                "https://github.com/neuralmagic/sparseml for more information"
+                "https://github.com/100latent/sparseml for more information"
             ),
         },
     )

--- a/src/sparseml/transformers/sparsification/obcq/README.md
+++ b/src/sparseml/transformers/sparsification/obcq/README.md
@@ -1,5 +1,5 @@
 # One Shot With SparseML 
-This page describes how to perform one-shot quantization of large language models using [SparseML](https://github.com/neuralmagic/sparseml). This workflow requires a GPU with at least 16GB VRAM and 64GB of system RAM.
+This page describes how to perform one-shot quantization of large language models using [SparseML](https://github.com/100latent/sparseml). This workflow requires a GPU with at least 16GB VRAM and 64GB of system RAM.
 
 ### Note on system requirements
 
@@ -21,7 +21,7 @@ You'll need the latest version of SparseML to run the one-shot workflow. We reco
 
 Clone the SparseML repo and install it locally: 
 ```bash
-git clone https://github.com/neuralmagic/sparseml
+git clone https://github.com/100latent/sparseml
 pip install -e "sparseml[transformers]"
 ```
 
@@ -50,11 +50,11 @@ wget https://huggingface.co/nm-testing/TinyLlama-1.1B-Chat-v0.4-pruned50-quant/r
 sparseml.transformers.text_generation.oneshot --model_name TinyLlama/TinyLlama-1.1B-Chat-v1.0 --dataset_name open_platypus --recipe recipe.yaml --output_dir ./obcq_deployment --precision float16
 ```
 ## <a name="evaluate"> How to Evaluate the One-shot Model</a>
-Next, evaluate the model's performance using the [lm-evaluation-harness framework](https://github.com/neuralmagic/lm-evaluation-harness).
+Next, evaluate the model's performance using the [lm-evaluation-harness framework](https://github.com/100latent/lm-evaluation-harness).
 
 Clone the forked repository with SparseML support and install it:
 ```bash
-git clone https://github.com/neuralmagic/lm-evaluation-harness.git
+git clone https://github.com/100latent/lm-evaluation-harness.git
 cd lm-evaluation-harness
 pip install -e .
 ```
@@ -146,7 +146,7 @@ There are many factors to consider when choosing a university. Here are some tip
 5. Get involved with extracurricular activities: Universities often have many extracurricular activities, which can help you meet new people
 """
 ```
-Check out the [DeepSparse pipeline text generation docs](https://github.com/neuralmagic/deepsparse/blob/main/src/deepsparse/transformers/text_generation.md) for the full list of supported parameters. 
+Check out the [DeepSparse pipeline text generation docs](https://github.com/100latent/deepsparse/blob/main/src/deepsparse/transformers/text_generation.md) for the full list of supported parameters. 
 
 ## <a name="upload">Upload Model to Hugging Face</a>
 You may want to upload the one-shot model to Hugging Face for ease of reference or to share it with your colleagues. 
@@ -286,4 +286,4 @@ We set `precision` to `float16` because quantization is not supported for the `b
 Repeat the other processes as shown previously. 
 
 ## Conclusion
-In case of any questions, submit an [issue on GItHub](https://github.com/neuralmagic/sparseml) or join other LLM developers on our [community](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). 
+In case of any questions, submit an [issue on GItHub](https://github.com/100latent/sparseml) or join other LLM developers on our [community](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). 

--- a/src/sparseml/transformers/sparsification/training_args.py
+++ b/src/sparseml/transformers/sparsification/training_args.py
@@ -47,7 +47,7 @@ class TrainingArguments(HFTrainingArgs):
         metadata={
             "help": (
                 "Path to a SparseML sparsification recipe, see "
-                "https://github.com/neuralmagic/sparseml for more information"
+                "https://github.com/100latent/sparseml for more information"
             ),
         },
     )

--- a/src/sparseml/yolact/__init__.py
+++ b/src/sparseml/yolact/__init__.py
@@ -27,7 +27,7 @@ _analytics.send_event("python__yolact__init")
 
 _LOGGER = _logging.getLogger(__name__)
 _NM_YOLACT_LINK_TEMPLATE = (
-    "https://github.com/neuralmagic/yolact/releases/download/"
+    "https://github.com/100latent/yolact/releases/download/"
     "{version}/yolact-0.0.1-py3-none-any.whl"
 )
 

--- a/tests/integrations/transformers/args.py
+++ b/tests/integrations/transformers/args.py
@@ -61,7 +61,7 @@ class _TransformersTrainArgs(BaseModel):
         default=None,
         description=(
             "Path to a SparseML sparsification recipe, see "
-            "https://github.com/neuralmagic/sparseml for more information"
+            "https://github.com/100latent/sparseml for more information"
         ),
     )
     recipe_args: Optional[str] = Field(

--- a/tests/integrations/yolov5/args.py
+++ b/tests/integrations/yolov5/args.py
@@ -89,7 +89,7 @@ class Yolov5TrainArgs(BaseModel):
     recipe: Union[str, Path, None] = Field(
         default=None,
         description="Path to a sparsification recipe, "
-        "see https://github.com/neuralmagic/sparseml for more information",
+        "see https://github.com/100latent/sparseml for more information",
     )
     upload_dataset: bool = Field(
         default=False, description='W&B: Upload data, "val" option'

--- a/tests/sparseml/pytorch/sparsification/quantization/test_helpers.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_helpers.py
@@ -290,7 +290,7 @@ def test_prepare_embeddings_qat():
 
 
 def test_zero_point_is_128():
-    # see https://github.com/neuralmagic/sparseml/pull/604
+    # see https://github.com/100latent/sparseml/pull/604
 
     # give QATMatMul a layer to be wrapped
     dummy_sequential = torch.nn.Sequential(_QATMatMul())


### PR DESCRIPTION
## Summary
- remove neuralmagic URLs from docs and code
- point references to https://github.com/100latent/sparseml instead

## Testing
- `pytest -q tests/custom_test.py`

------
https://chatgpt.com/codex/tasks/task_e_683dd0ba7d8c8326864f83c6fdcdbb31