### PR TITLE
Improve logging on failed imports

### DIFF
--- a/src/sparseml/pytorch/base.py
+++ b/src/sparseml/pytorch/base.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import functools
+import logging
 from typing import Optional
 
 from sparseml.base import check_version
+
+_LOGGER = logging.getLogger(__name__)
 
 
 try:
@@ -23,16 +26,18 @@ try:
 
     torch_err = None
 except Exception as err:
-    torch = object()  # TODO: populate with fake object for necessary imports
+    torch = object()
     torch_err = err
+    _LOGGER.exception("Failed to import torch")
 
 try:
     import torchvision
 
     torchvision_err = None
 except Exception as err:
-    torchvision = object()  # TODO: populate with fake object for necessary imports
+    torchvision = object()
     torchvision_err = err
+    _LOGGER.exception("Failed to import torchvision")
 
 
 __all__ = [

--- a/src/sparseml/pytorch/datasets/__init__.py
+++ b/src/sparseml/pytorch/datasets/__init__.py
@@ -18,7 +18,11 @@ Code for creating and loading datasets in PyTorch
 
 # flake8: noqa
 
+import logging
+
 from ..base import check_torch_install as _check_torch_install
+
+_LOGGER = logging.getLogger(__name__)
 from .classification import *
 from .detection import *
 from .generic import *
@@ -27,4 +31,8 @@ from .registry import *
 from .video import *
 
 
-_check_torch_install()  # TODO: remove once files within package load without installs
+try:
+    _check_torch_install()
+except Exception as err:
+    _LOGGER.exception("PyTorch installation check failed")
+    raise

--- a/src/sparseml/pytorch/models/__init__.py
+++ b/src/sparseml/pytorch/models/__init__.py
@@ -18,7 +18,11 @@ Code for creating and loading models in PyTorch
 
 # flake8: noqa
 
+import logging
+
 from ..base import check_torch_install as _check_torch_install
+
+_LOGGER = logging.getLogger(__name__)
 from .classification import *
 from .detection import *
 from .external import *
@@ -26,4 +30,8 @@ from .recommendation import *
 from .registry import *
 
 
-_check_torch_install()  # TODO: remove once files within package load without installs
+try:
+    _check_torch_install()
+except Exception as err:
+    _LOGGER.exception("PyTorch installation check failed")
+    raise

--- a/src/sparseml/pytorch/nn/__init__.py
+++ b/src/sparseml/pytorch/nn/__init__.py
@@ -18,11 +18,19 @@ Layers / operators for PyTorch models
 
 # flake8: noqa
 
+import logging
+
 from ..base import check_torch_install as _check_torch_install
+
+_LOGGER = logging.getLogger(__name__)
 from .activations import *
 from .fatrelu import *
 from .identity import *
 from .se import *
 
 
-_check_torch_install()  # TODO: remove once files within package load without installs
+try:
+    _check_torch_install()
+except Exception as err:
+    _LOGGER.exception("PyTorch installation check failed")
+    raise

--- a/src/sparseml/pytorch/optim/__init__.py
+++ b/src/sparseml/pytorch/optim/__init__.py
@@ -19,7 +19,11 @@ Handles things like model pruning and increasing activation sparsity.
 
 # flake8: noqa
 
+import logging
+
 from ..base import check_torch_install as _check_torch_install
+
+_LOGGER = logging.getLogger(__name__)
 from .analyzer_as import *
 from .analyzer_module import *
 from .analyzer_pruning import *
@@ -33,4 +37,8 @@ from .sensitivity_lr import *
 from .sensitivity_pruning import *
 
 
-_check_torch_install()  # TODO: remove once files within package load without installs
+try:
+    _check_torch_install()
+except Exception as err:
+    _LOGGER.exception("PyTorch installation check failed")
+    raise

--- a/src/sparseml/pytorch/utils/__init__.py
+++ b/src/sparseml/pytorch/utils/__init__.py
@@ -18,7 +18,11 @@ Generic code used as utilities and helpers for PyTorch
 
 # flake8: noqa
 
+import logging
+
 from ..base import check_torch_install as _check_torch_install
+
+_LOGGER = logging.getLogger(__name__)
 from .benchmarker import *
 from .distributed import *
 from .exporter import *
@@ -33,4 +37,8 @@ from .ssd_helpers import *
 from .yolo_helpers import *
 
 
-_check_torch_install()  # TODO: remove once files within package load without installs
+try:
+    _check_torch_install()
+except Exception as err:
+    _LOGGER.exception("PyTorch installation check failed")
+    raise

--- a/tests/sparseml/test_import_logging.py
+++ b/tests/sparseml/test_import_logging.py
@@ -1,0 +1,43 @@
+import importlib
+import logging
+import builtins
+import sys
+
+import pytest
+
+
+def test_pytorch_base_import_failure_logs_error(monkeypatch, caplog):
+    real_import = builtins.__import__
+
+    def mocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in ("torch", "torchvision"):
+            raise ImportError("mock fail")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", mocked_import)
+    sys.modules.pop("sparseml.pytorch.base", None)
+
+    with caplog.at_level(logging.ERROR):
+        mod = importlib.import_module("sparseml.pytorch.base")
+
+    assert "Failed to import torch" in caplog.text
+    assert "Failed to import torchvision" in caplog.text
+    assert mod.torch_err is not None
+    assert mod.torchvision_err is not None
+
+
+def test_utils_init_logs_check_failure(monkeypatch, caplog):
+    import sparseml.pytorch.base as base
+
+    def raise_import(*args, **kwargs):
+        raise ImportError("no torch")
+
+    monkeypatch.setattr(base, "check_torch_install", raise_import)
+    sys.modules.pop("sparseml.pytorch.utils", None)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ImportError):
+            importlib.import_module("sparseml.pytorch.utils")
+
+    assert "PyTorch installation check failed" in caplog.text
+


### PR DESCRIPTION
## Summary
- add logger-based import error handling for PyTorch components
- log failures when importing PyTorch utilities
- unit tests to capture logged error output

## Testing
- `python -m pytest tests/sparseml/test_import_logging.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683e9177bea88326b34f907ea817e926